### PR TITLE
fix:allow_workshop_300

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fann2>=1.0.7, < 1.1.0
 xxhash
 ovos-plugin-manager>=0.5.0,<1.0.0
-ovos-workshop>=0.1.7,<3.0.0
+ovos-workshop>=0.1.7,<4.0.0
 ovos-utils>=0.3.4,<1.0.0
 langcodes


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the version constraint for the `ovos-workshop` package to allow for newer versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->