### PR TITLE
feat(opm): add DomainPadatiousPipeline OPM entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,17 @@ This repository contains a OVOS pipeline plugin and bundles a fork of the origin
  - Easily extract entities (ie. Find the nearest *gas station* -> `place: gas station`)
  - Fast training with a modular approach to neural networks
 
+## OPM Pipeline Entry Points
+
+Two pipeline entry points are registered:
+
+| Entry point | Backed by | When to use |
+|---|---|---|
+| `ovos-padatious-pipeline-plugin` | `IntentContainer` | Flat intent registry (default). |
+| `ovos-padatious-domain-pipeline-plugin` | `DomainIntentContainer` | Group intents by `skill_id` (domain); every sub-domain scores the query in parallel and the global argmax wins. |
+
+The legacy `domain_engine: true` config flag on the flat pipeline still works but is **deprecated** — prefer selecting `ovos-padatious-domain-pipeline-plugin` at the pipeline level. See [`docs/ovos_pipeline.md`](docs/ovos_pipeline.md) for full details.
+
 
 ### Installing
 

--- a/benchmark/compare.py
+++ b/benchmark/compare.py
@@ -39,6 +39,54 @@ logging.disable(logging.CRITICAL)
 _CI_MODE = "--ci" in sys.argv
 
 
+# ── calibration helpers ────────────────────────────────────────────────────
+
+def fbeta(precision, recall, beta=0.5):
+    """F_β score. β<1 weights precision over recall — appropriate for voice
+    assistants where a false positive (wrong skill fires) is unrecoverable
+    while a false negative falls through to fallback handlers (LLM, etc.).
+    """
+    b2 = beta * beta
+    denom = b2 * precision + recall
+    return ((1 + b2) * precision * recall / denom) if denom else 0.0
+
+
+def recall_at_precision(results_no_thresh, cases, p_floor=0.99, step=0.01):
+    """Sweep the threshold and return the max recall achievable while
+    keeping precision >= ``p_floor`` (and the threshold that gets there).
+    """
+    best_r, best_t = 0.0, None
+    t = 0.0
+    while t <= 1.0 + 1e-9:
+        thresholded = [
+            (lbl if c >= t else None, c) for (lbl, c) in results_no_thresh
+        ]
+        m = compute_metrics(thresholded, cases)
+        if m["precision"] >= p_floor and m["recall"] > best_r:
+            best_r, best_t = m["recall"], round(t, 4)
+        t += step
+    return best_r, best_t
+
+
+def calibrate_threshold(results_no_thresh, cases, step=0.01, metric="f0.5"):
+    """Sweep threshold and return (best_threshold, best_metric_value, best_metrics)."""
+    def score(m):
+        return m["f1"] if metric == "f1" else fbeta(m["precision"], m["recall"], 0.5)
+
+    best = (0.0, -1.0, None)
+    t = 0.0
+    while t <= 1.0 + 1e-9:
+        thresholded = [
+            (lbl if c >= t else None, c) for (lbl, c) in results_no_thresh
+        ]
+        m = compute_metrics(thresholded, cases)
+        s = score(m)
+        if s > best[1]:
+            best = (round(t, 4), s, m)
+        t += step
+    return best
+
+
 # ── shared helpers ─────────────────────────────────────────────────────────
 
 def all_cases(bundle):
@@ -171,7 +219,7 @@ def run_padaos(bundle, cases):
 
     m = compute_metrics(results, cases)
     print_report("padaos  (regex, no fuzz)", m, latencies, bundle.intents, train_ms)
-    return m, statistics.median(latencies), statistics.mean(latencies), train_ms
+    return m, statistics.median(latencies), statistics.mean(latencies), train_ms, None
 
 
 def run_nebulento(bundle, cases, threshold=0.5):
@@ -189,17 +237,17 @@ def run_nebulento(bundle, cases, threshold=0.5):
         print(f"[SKIP] nebulento — registration failed: {e}")
         return None
 
-    results, latencies = [], []
+    raw, latencies = [], []
     for utt, _ in cases:
         t0 = time.perf_counter()
         r  = c.calc_intent(utt)
         latencies.append((time.perf_counter() - t0) * 1000)
-        predicted = r.get("name") if (r and r.get("conf", 0) >= threshold) else None
-        results.append((predicted, r.get("conf", 0.0) if r else 0.0))
+        raw.append((r.get("name") if r else None, r.get("conf", 0.0) if r else 0.0))
 
+    results = [(lbl if cf >= threshold else None, cf) for (lbl, cf) in raw]
     m = compute_metrics(results, cases)
     print_report("nebulento  (fuzzy, damerau-levenshtein)", m, latencies, bundle.intents)
-    return m, statistics.median(latencies), statistics.mean(latencies), None
+    return m, statistics.median(latencies), statistics.mean(latencies), None, raw
 
 
 def run_padatious_flat(bundle, cases, threshold=0.5):
@@ -219,18 +267,18 @@ def run_padatious_flat(bundle, cases, threshold=0.5):
         c.train(single_thread=True, debug=False)
         train_ms = (time.perf_counter() - t0) * 1000
 
-        results, latencies = [], []
+        raw, latencies = [], []
         for utt, _ in cases:
             t0 = time.perf_counter()
             r  = c.calc_intent(normalize_utterance(utt))
             latencies.append((time.perf_counter() - t0) * 1000)
-            predicted = r.name if (r and r.conf >= threshold) else None
-            results.append((predicted, r.conf if r else 0.0))
+            raw.append((r.name if r else None, r.conf if r else 0.0))
 
+    results = [(lbl if cf >= threshold else None, cf) for (lbl, cf) in raw]
     m = compute_metrics(results, cases)
     print_report(f"padatious flat  (neural, threshold={threshold})", m, latencies,
                  bundle.intents, train_ms)
-    return m, statistics.median(latencies), statistics.mean(latencies), train_ms
+    return m, statistics.median(latencies), statistics.mean(latencies), train_ms, raw
 
 
 def run_padatious_domain(bundle, cases, threshold=0.5):
@@ -259,18 +307,18 @@ def run_padatious_domain(bundle, cases, threshold=0.5):
         c.train()
         train_ms = (time.perf_counter() - t0) * 1000
 
-        results, latencies = [], []
+        raw, latencies = [], []
         for utt, _ in cases:
             t0 = time.perf_counter()
             r  = c.calc_intent(normalize_utterance(utt))
             latencies.append((time.perf_counter() - t0) * 1000)
-            predicted = r.name if (r and r.conf >= threshold) else None
-            results.append((predicted, r.conf if r else 0.0))
+            raw.append((r.name if r else None, r.conf if r else 0.0))
 
+    results = [(lbl if cf >= threshold else None, cf) for (lbl, cf) in raw]
     m = compute_metrics(results, cases)
     print_report(f"padatious domain  (parallel, threshold={threshold})", m, latencies,
                  bundle.intents, train_ms)
-    return m, statistics.median(latencies), statistics.mean(latencies), train_ms
+    return m, statistics.median(latencies), statistics.mean(latencies), train_ms, raw
 
 
 def run_padatious_hierarchical(bundle, cases, threshold=0.5, domain_threshold=0.0):
@@ -300,18 +348,18 @@ def run_padatious_hierarchical(bundle, cases, threshold=0.5, domain_threshold=0.
         c.train()
         train_ms = (time.perf_counter() - t0) * 1000
 
-        results, latencies = [], []
+        raw, latencies = [], []
         for utt, _ in cases:
             t0 = time.perf_counter()
             r  = c.calc_intent(normalize_utterance(utt))
             latencies.append((time.perf_counter() - t0) * 1000)
-            predicted = r.name if (r and r.conf >= threshold) else None
-            results.append((predicted, r.conf if r else 0.0))
+            raw.append((r.name if r else None, r.conf if r else 0.0))
 
+    results = [(lbl if cf >= threshold else None, cf) for (lbl, cf) in raw]
     m = compute_metrics(results, cases)
     print_report(f"padatious hierarchical  (two-stage, threshold={threshold})", m,
                  latencies, bundle.intents, train_ms)
-    return m, statistics.median(latencies), statistics.mean(latencies), train_ms
+    return m, statistics.median(latencies), statistics.mean(latencies), train_ms, raw
 
 
 # ── summary table ──────────────────────────────────────────────────────────
@@ -353,23 +401,69 @@ def run_dataset(name):
     print("Splits  : " + ", ".join(f"{k}={len(v)}" for k, v in bundle.splits.items()))
 
     rows = []
+    cal_rows = []
 
-    def _add(label, res):
+    def _add(label, res, cal_label=None, default_thr=0.5):
         if res is not None:
-            m, lat, mean_lat, tr = res
+            m, lat, mean_lat, tr, raw = res
             rows.append((label, m, lat, mean_lat, tr))
+            if cal_label is not None and raw is not None:
+                cal_rows.append(_calibrate_row(cal_label, raw, cases, default_thr, m))
 
     # baselines
     _add("padaos", run_padaos(bundle, cases))
-    _add("nebulento", run_nebulento(bundle, cases, threshold=0.5))
+    _add("nebulento", run_nebulento(bundle, cases, threshold=0.5),
+         cal_label="nebulento")
 
     # subject — this repo's three engines
-    _add("padatious flat", run_padatious_flat(bundle, cases, threshold=0.5))
-    _add("padatious domain", run_padatious_domain(bundle, cases, threshold=0.5))
+    _add("padatious flat", run_padatious_flat(bundle, cases, threshold=0.5),
+         cal_label="padatious flat")
+    _add("padatious domain", run_padatious_domain(bundle, cases, threshold=0.5),
+         cal_label="padatious domain")
     _add("padatious hierarchical",
-         run_padatious_hierarchical(bundle, cases, threshold=0.5, domain_threshold=0.0))
+         run_padatious_hierarchical(bundle, cases, threshold=0.5, domain_threshold=0.0),
+         cal_label="padatious hierarchical")
 
     summary(f"{name}  —  {bundle.repo}", rows)
+    _print_calibration_table(cal_rows)
+
+
+def _calibrate_row(label, raw, cases, default_thr, default_metrics):
+    """Compute the calibration row for one engine."""
+    df1 = default_metrics["f1"]
+    dfp = default_metrics["fp"]
+    df05 = fbeta(default_metrics["precision"], default_metrics["recall"], 0.5)
+    opt_thr, _, opt_metrics = calibrate_threshold(raw, cases, step=0.01,
+                                                  metric="f0.5")
+    of1 = opt_metrics["f1"]
+    ofp = opt_metrics["fp"]
+    of05 = fbeta(opt_metrics["precision"], opt_metrics["recall"], 0.5)
+    rec_at_p, rec_thr = recall_at_precision(raw, cases, p_floor=0.99, step=0.01)
+    return (label, default_thr, df1, df05, dfp,
+            opt_thr, of1, of05, ofp, rec_at_p, rec_thr)
+
+
+def _print_calibration_table(rows):
+    if not rows:
+        return
+    print(f"\n{'─'*108}")
+    print("  Per-engine threshold calibration  (sweep 0..1 step 0.01, max F_0.5)")
+    print(f"  {'Engine':<24} {'def_thr':>7} {'def_F1':>7} {'defF.5':>7} {'def_FP':>6}"
+          f"  {'opt_thr':>7} {'opt_F1':>7} {'optF.5':>7} {'opt_FP':>6}"
+          f"  {'R@P99':>6} {'thr':>5}")
+    print(f"{'─'*108}")
+    for r in rows:
+        (label, dthr, df1, df05, dfp,
+         othr, of1, of05, ofp, rec_at_p, rec_thr) = r
+        rec_t = f"{rec_thr:.2f}" if rec_thr is not None else "--"
+        print(f"  {label:<24} {dthr:>7.2f} {df1:>7.3f} {df05:>7.3f} {dfp:>6d}"
+              f"  {othr:>7.2f} {of1:>7.3f} {of05:>7.3f} {ofp:>6d}"
+              f"  {rec_at_p:>6.1%} {rec_t:>5}")
+    print(f"{'─'*108}")
+    print("  F_0.5 (β=0.5) weights precision 2x recall — the right summary metric")
+    print("  for OVOS, where a wrong intent is unrecoverable but a missed intent")
+    print("  falls through to fallback handlers. R@P99 = max recall achievable")
+    print("  with the threshold tuned to keep precision >= 99%.")
 
 
 if __name__ == "__main__":

--- a/benchmark/compare.py
+++ b/benchmark/compare.py
@@ -180,10 +180,14 @@ def run_nebulento(bundle, cases, threshold=0.5):
     from nebulento.fuzz import MatchStrategy
     strategy = MatchStrategy.DAMERAU_LEVENSHTEIN_SIMILARITY
     c = IntentContainer(fuzzy_strategy=strategy)
-    for entity_name, samples in bundle.entities.items():
-        c.add_entity(entity_name, samples)
-    for name, data in bundle.intents.items():
-        c.add_intent(name, data["train"])
+    try:
+        for entity_name, samples in bundle.entities.items():
+            c.add_entity(entity_name, samples)
+        for name, data in bundle.intents.items():
+            c.add_intent(name, data["train"])
+    except Exception as e:
+        print(f"[SKIP] nebulento — registration failed: {e}")
+        return None
 
     results, latencies = [], []
     for utt, _ in cases:
@@ -203,10 +207,14 @@ def run_padatious_flat(bundle, cases, threshold=0.5):
     from ovos_padatious import IntentContainer as PC
     with tempfile.TemporaryDirectory() as d:
         c = PC(cache_dir=d)
-        for entity_name, samples in bundle.entities.items():
-            c.add_entity(entity_name, samples)
-        for name, data in bundle.intents.items():
-            c.add_intent(name, data["train"])
+        try:
+            for entity_name, samples in bundle.entities.items():
+                c.add_entity(entity_name, samples)
+            for name, data in bundle.intents.items():
+                c.add_intent(name, data["train"])
+        except Exception as e:
+            print(f"[SKIP] padatious flat — registration failed: {e}")
+            return None
         t0 = time.perf_counter()
         c.train(single_thread=True, debug=False)
         train_ms = (time.perf_counter() - t0) * 1000
@@ -233,16 +241,20 @@ def run_padatious_domain(bundle, cases, threshold=0.5):
                      for intent in intents}
     with tempfile.TemporaryDirectory() as d:
         c = DomainIntentContainer(cache_dir=d)
-        for name, data in bundle.intents.items():
-            c.add_domain_intent(intent_domain[name], name, data["train"])
-        # register each entity in every domain whose intents reference it
-        domain_entities = defaultdict(set)
-        for name, data in bundle.intents.items():
-            for entity_name in data["entities"]:
-                domain_entities[intent_domain[name]].add(entity_name)
-        for dom, entity_names in domain_entities.items():
-            for entity_name in entity_names:
-                c.add_domain_entity(dom, entity_name, bundle.entities[entity_name])
+        try:
+            for name, data in bundle.intents.items():
+                c.add_domain_intent(intent_domain[name], name, data["train"])
+            # register each entity in every domain whose intents reference it
+            domain_entities = defaultdict(set)
+            for name, data in bundle.intents.items():
+                for entity_name in data["entities"]:
+                    domain_entities[intent_domain[name]].add(entity_name)
+            for dom, entity_names in domain_entities.items():
+                for entity_name in entity_names:
+                    c.add_domain_entity(dom, entity_name, bundle.entities[entity_name])
+        except Exception as e:
+            print(f"[SKIP] padatious domain — registration failed: {e}")
+            return None
         t0 = time.perf_counter()
         c.train()
         train_ms = (time.perf_counter() - t0) * 1000
@@ -270,16 +282,20 @@ def run_padatious_hierarchical(bundle, cases, threshold=0.5, domain_threshold=0.
     with tempfile.TemporaryDirectory() as d:
         c = HierarchicalIntentContainer(cache_dir=d,
                                         domain_threshold=domain_threshold)
-        for name, data in bundle.intents.items():
-            c.add_domain_intent(intent_domain[name], name, data["train"])
-        # register each entity in every domain whose intents reference it
-        domain_entities = defaultdict(set)
-        for name, data in bundle.intents.items():
-            for entity_name in data["entities"]:
-                domain_entities[intent_domain[name]].add(entity_name)
-        for dom, entity_names in domain_entities.items():
-            for entity_name in entity_names:
-                c.add_domain_entity(dom, entity_name, bundle.entities[entity_name])
+        try:
+            for name, data in bundle.intents.items():
+                c.add_domain_intent(intent_domain[name], name, data["train"])
+            # register each entity in every domain whose intents reference it
+            domain_entities = defaultdict(set)
+            for name, data in bundle.intents.items():
+                for entity_name in data["entities"]:
+                    domain_entities[intent_domain[name]].add(entity_name)
+            for dom, entity_names in domain_entities.items():
+                for entity_name in entity_names:
+                    c.add_domain_entity(dom, entity_name, bundle.entities[entity_name])
+        except Exception as e:
+            print(f"[SKIP] padatious hierarchical — registration failed: {e}")
+            return None
         t0 = time.perf_counter()
         c.train()
         train_ms = (time.perf_counter() - t0) * 1000
@@ -337,23 +353,21 @@ def run_dataset(name):
     print("Splits  : " + ", ".join(f"{k}={len(v)}" for k, v in bundle.splits.items()))
 
     rows = []
-    # baselines
-    m, lat, mean_lat, tr = run_padaos(bundle, cases)
-    rows.append(("padaos", m, lat, mean_lat, tr))
 
-    m, lat, mean_lat, tr = run_nebulento(bundle, cases, threshold=0.5)
-    rows.append(("nebulento", m, lat, mean_lat, tr))
+    def _add(label, res):
+        if res is not None:
+            m, lat, mean_lat, tr = res
+            rows.append((label, m, lat, mean_lat, tr))
+
+    # baselines
+    _add("padaos", run_padaos(bundle, cases))
+    _add("nebulento", run_nebulento(bundle, cases, threshold=0.5))
 
     # subject — this repo's three engines
-    m, lat, mean_lat, tr = run_padatious_flat(bundle, cases, threshold=0.5)
-    rows.append(("padatious flat", m, lat, mean_lat, tr))
-
-    m, lat, mean_lat, tr = run_padatious_domain(bundle, cases, threshold=0.5)
-    rows.append(("padatious domain", m, lat, mean_lat, tr))
-
-    m, lat, mean_lat, tr = run_padatious_hierarchical(bundle, cases, threshold=0.5,
-                                                      domain_threshold=0.0)
-    rows.append(("padatious hierarchical", m, lat, mean_lat, tr))
+    _add("padatious flat", run_padatious_flat(bundle, cases, threshold=0.5))
+    _add("padatious domain", run_padatious_domain(bundle, cases, threshold=0.5))
+    _add("padatious hierarchical",
+         run_padatious_hierarchical(bundle, cases, threshold=0.5, domain_threshold=0.0))
 
     summary(f"{name}  —  {bundle.repo}", rows)
 

--- a/benchmark/compare.py
+++ b/benchmark/compare.py
@@ -1,0 +1,368 @@
+"""
+Comparative accuracy + speed benchmark across intent engines.
+
+Engines
+-------
+padaos                  – regex-based matcher (baseline)
+nebulento               – fuzzy string matching engine (baseline)
+padatious flat          – this repo's neural-network matcher
+padatious domain        – this repo's parallel per-domain DomainIntentContainer
+padatious hierarchical  – this repo's two-stage HierarchicalIntentContainer
+
+The three padatious rows are the subject of this benchmark; padaos and
+nebulento are the fixed external baselines, shared across the OVOS intent
+engine family so results stay comparable.
+
+Every engine here is a template / sample matcher: it trains on example
+sentences, not keyword vocabularies. They are evaluated on two OpenVoiceOS
+datasets — ``intents-for-eval`` and ``massive`` — each engine training on the
+``<lang>-templates`` config and evaluating on ``<lang>-test``. See
+``benchmark/dataset.py``.
+
+Usage
+-----
+    python benchmark/compare.py
+"""
+import sys
+import time
+import tempfile
+import statistics
+import logging
+from collections import defaultdict
+
+from nebulento.bracket_expansion import normalize_utterance
+
+from benchmark.dataset import DATASETS, load
+
+logging.disable(logging.CRITICAL)
+
+_CI_MODE = "--ci" in sys.argv
+
+
+# ── shared helpers ─────────────────────────────────────────────────────────
+
+def all_cases(bundle):
+    """Flatten a :class:`~benchmark.dataset.Bundle` into ``(utterance, expected)``."""
+    cases = []
+    for name, data in bundle.intents.items():
+        for utt in data["test_match"]:
+            cases.append((utt, name))
+    for utt in bundle.no_match:
+        cases.append((utt, None))
+    return cases
+
+
+def compute_metrics(results, cases):
+    total     = len(cases)
+    match_n   = sum(1 for _, e in cases if e is not None)
+    nomatch_n = total - match_n
+    tp = fp = fn = tn = 0
+    per_tp = defaultdict(int)
+    per_fn = defaultdict(int)
+    per_fp = defaultdict(int)
+    wrong  = []
+    for (predicted, conf), (utt, expected) in zip(results, cases):
+        if expected is not None:
+            if predicted == expected:
+                tp += 1
+                per_tp[expected] += 1
+            else:
+                fn += 1
+                per_fn[expected] += 1
+                wrong.append((utt, expected, predicted, conf))
+        else:
+            if predicted is not None:
+                fp += 1
+                per_fp[predicted] += 1
+                wrong.append((utt, expected, predicted, conf))
+            else:
+                tn += 1
+    precision = tp / (tp + fp) if (tp + fp) else 0.0
+    recall    = tp / match_n   if match_n   else 0.0
+    f1        = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+    return dict(
+        accuracy=(tp + tn) / total if total else 0.0,
+        precision=precision, recall=recall, f1=f1,
+        fp=fp, fn=fn, match_n=match_n, nomatch_n=nomatch_n,
+        per_tp=per_tp, per_fn=per_fn, per_fp=per_fp, wrong=wrong,
+    )
+
+
+def _stats_lines(label, metrics, latencies, intents, train_ms=None):
+    s = sorted(latencies)
+    total = metrics['match_n'] + metrics['nomatch_n']
+    nomatch_n = metrics['nomatch_n']
+    match_n = metrics['match_n']
+    fp_pct = f"  ({metrics['fp']/nomatch_n:.0%} of no-match)" if nomatch_n else ""
+    fn_pct = f"  ({metrics['fn']/match_n:.0%} of match)" if match_n else ""
+    lines = [
+        f"{'='*64}",
+        f"  {label}",
+        f"{'='*64}",
+    ]
+    if train_ms is not None:
+        lines.append(f"  Train time: {train_ms:.0f} ms")
+    lines += [
+        f"  Accuracy  : {metrics['accuracy']:.1%}  ({int(metrics['accuracy']*total)}/{total})",
+        f"  Precision : {metrics['precision']:.1%}",
+        f"  Recall    : {metrics['recall']:.1%}",
+        f"  F1        : {metrics['f1']:.3f}",
+        f"  FP        : {metrics['fp']} / {nomatch_n}{fp_pct}",
+        f"  FN        : {metrics['fn']} / {match_n}{fn_pct}",
+        f"  Latency   : median={statistics.median(latencies):.2f}ms  "
+        f"p95={s[int(len(s)*.95)]:.2f}ms  max={s[-1]:.2f}ms",
+    ]
+    issues = sorted(set(metrics['per_fn']) | set(metrics['per_fp']))
+    if issues:
+        lines.append("")
+        lines.append("  Per-intent (issues only):")
+        for i in sorted(intents):
+            fn = metrics['per_fn'].get(i, 0)
+            fp = metrics['per_fp'].get(i, 0)
+            tp = metrics['per_tp'].get(i, 0)
+            if fn or fp:
+                rec = tp / (tp + fn) if (tp + fn) else 0
+                lines.append(f"    {i:<28}  recall={rec:.0%}  fn={fn}  fp={fp}")
+    return lines
+
+
+def print_report(label, metrics, latencies, intents, train_ms=None):
+    lines = _stats_lines(label, metrics, latencies, intents, train_ms)
+    if _CI_MODE:
+        acc = metrics['accuracy']
+        fp  = metrics['fp']
+        med = statistics.median(latencies)
+        print("<details>")
+        print(f"<summary><b>{label}</b> &mdash; acc {acc:.1%} &middot; "
+              f"FP {fp} &middot; median {med:.2f}ms</summary>")
+        print()
+        print("```text")
+        for line in lines:
+            print(line)
+        print("```")
+        print()
+        print("</details>")
+        print()
+    else:
+        for line in lines:
+            print(line)
+
+
+# ── engine runners ─────────────────────────────────────────────────────────
+
+def run_padaos(bundle, cases):
+    import padaos
+    c = padaos.IntentContainer()
+    for entity_name, samples in bundle.entities.items():
+        c.add_entity(entity_name, samples)
+    for name, data in bundle.intents.items():
+        c.add_intent(name, data["train"])
+    t0 = time.perf_counter()
+    c.compile()
+    train_ms = (time.perf_counter() - t0) * 1000
+
+    results, latencies = [], []
+    for utt, _ in cases:
+        q = normalize_utterance(utt)
+        t0 = time.perf_counter()
+        r  = c.calc_intent(q)
+        latencies.append((time.perf_counter() - t0) * 1000)
+        results.append((r.get("name"), 1.0 if r.get("name") else 0.0))
+
+    m = compute_metrics(results, cases)
+    print_report("padaos  (regex, no fuzz)", m, latencies, bundle.intents, train_ms)
+    return m, statistics.median(latencies), statistics.mean(latencies), train_ms
+
+
+def run_nebulento(bundle, cases, threshold=0.5):
+    """Baseline — flat nebulento with its default DAMERAU_LEVENSHTEIN strategy."""
+    from nebulento import IntentContainer
+    from nebulento.fuzz import MatchStrategy
+    strategy = MatchStrategy.DAMERAU_LEVENSHTEIN_SIMILARITY
+    c = IntentContainer(fuzzy_strategy=strategy)
+    for entity_name, samples in bundle.entities.items():
+        c.add_entity(entity_name, samples)
+    for name, data in bundle.intents.items():
+        c.add_intent(name, data["train"])
+
+    results, latencies = [], []
+    for utt, _ in cases:
+        t0 = time.perf_counter()
+        r  = c.calc_intent(utt)
+        latencies.append((time.perf_counter() - t0) * 1000)
+        predicted = r.get("name") if (r and r.get("conf", 0) >= threshold) else None
+        results.append((predicted, r.get("conf", 0.0) if r else 0.0))
+
+    m = compute_metrics(results, cases)
+    print_report("nebulento  (fuzzy, damerau-levenshtein)", m, latencies, bundle.intents)
+    return m, statistics.median(latencies), statistics.mean(latencies), None
+
+
+def run_padatious_flat(bundle, cases, threshold=0.5):
+    """Subject — this repo's flat neural IntentContainer."""
+    from ovos_padatious import IntentContainer as PC
+    with tempfile.TemporaryDirectory() as d:
+        c = PC(cache_dir=d)
+        for entity_name, samples in bundle.entities.items():
+            c.add_entity(entity_name, samples)
+        for name, data in bundle.intents.items():
+            c.add_intent(name, data["train"])
+        t0 = time.perf_counter()
+        c.train(single_thread=True, debug=False)
+        train_ms = (time.perf_counter() - t0) * 1000
+
+        results, latencies = [], []
+        for utt, _ in cases:
+            t0 = time.perf_counter()
+            r  = c.calc_intent(normalize_utterance(utt))
+            latencies.append((time.perf_counter() - t0) * 1000)
+            predicted = r.name if (r and r.conf >= threshold) else None
+            results.append((predicted, r.conf if r else 0.0))
+
+    m = compute_metrics(results, cases)
+    print_report(f"padatious flat  (neural, threshold={threshold})", m, latencies,
+                 bundle.intents, train_ms)
+    return m, statistics.median(latencies), statistics.mean(latencies), train_ms
+
+
+def run_padatious_domain(bundle, cases, threshold=0.5):
+    """Subject — this repo's per-domain DomainIntentContainer (parallel argmax)."""
+    from ovos_padatious.domain_container import DomainIntentContainer
+    intent_domain = {intent: dom
+                     for dom, intents in bundle.domains.items()
+                     for intent in intents}
+    with tempfile.TemporaryDirectory() as d:
+        c = DomainIntentContainer(cache_dir=d)
+        for name, data in bundle.intents.items():
+            c.add_domain_intent(intent_domain[name], name, data["train"])
+        # register each entity in every domain whose intents reference it
+        domain_entities = defaultdict(set)
+        for name, data in bundle.intents.items():
+            for entity_name in data["entities"]:
+                domain_entities[intent_domain[name]].add(entity_name)
+        for dom, entity_names in domain_entities.items():
+            for entity_name in entity_names:
+                c.add_domain_entity(dom, entity_name, bundle.entities[entity_name])
+        t0 = time.perf_counter()
+        c.train()
+        train_ms = (time.perf_counter() - t0) * 1000
+
+        results, latencies = [], []
+        for utt, _ in cases:
+            t0 = time.perf_counter()
+            r  = c.calc_intent(normalize_utterance(utt))
+            latencies.append((time.perf_counter() - t0) * 1000)
+            predicted = r.name if (r and r.conf >= threshold) else None
+            results.append((predicted, r.conf if r else 0.0))
+
+    m = compute_metrics(results, cases)
+    print_report(f"padatious domain  (parallel, threshold={threshold})", m, latencies,
+                 bundle.intents, train_ms)
+    return m, statistics.median(latencies), statistics.mean(latencies), train_ms
+
+
+def run_padatious_hierarchical(bundle, cases, threshold=0.5, domain_threshold=0.0):
+    """Subject — this repo's two-stage HierarchicalIntentContainer."""
+    from ovos_padatious.hierarchical_container import HierarchicalIntentContainer
+    intent_domain = {intent: dom
+                     for dom, intents in bundle.domains.items()
+                     for intent in intents}
+    with tempfile.TemporaryDirectory() as d:
+        c = HierarchicalIntentContainer(cache_dir=d,
+                                        domain_threshold=domain_threshold)
+        for name, data in bundle.intents.items():
+            c.add_domain_intent(intent_domain[name], name, data["train"])
+        # register each entity in every domain whose intents reference it
+        domain_entities = defaultdict(set)
+        for name, data in bundle.intents.items():
+            for entity_name in data["entities"]:
+                domain_entities[intent_domain[name]].add(entity_name)
+        for dom, entity_names in domain_entities.items():
+            for entity_name in entity_names:
+                c.add_domain_entity(dom, entity_name, bundle.entities[entity_name])
+        t0 = time.perf_counter()
+        c.train()
+        train_ms = (time.perf_counter() - t0) * 1000
+
+        results, latencies = [], []
+        for utt, _ in cases:
+            t0 = time.perf_counter()
+            r  = c.calc_intent(normalize_utterance(utt))
+            latencies.append((time.perf_counter() - t0) * 1000)
+            predicted = r.name if (r and r.conf >= threshold) else None
+            results.append((predicted, r.conf if r else 0.0))
+
+    m = compute_metrics(results, cases)
+    print_report(f"padatious hierarchical  (two-stage, threshold={threshold})", m,
+                 latencies, bundle.intents, train_ms)
+    return m, statistics.median(latencies), statistics.mean(latencies), train_ms
+
+
+# ── summary table ──────────────────────────────────────────────────────────
+
+def summary(title, rows):
+    """rows: list of (label, metrics, median_lat_ms, mean_lat_ms, train_ms_or_None)"""
+    if _CI_MODE:
+        print(f"## {title}\n")
+        print("| Engine | Acc | Prec | Recall | F1 | FP | Median |")
+        print("|---|---|---|---|---|---|---|")
+        for label, m, median_lat, mean_lat, _ in rows:
+            print(f"| {label} | {m['accuracy']:.1%} | {m['precision']:.1%} | "
+                  f"{m['recall']:.1%} | {m['f1']:.3f} | {m['fp']} | {median_lat:.2f}ms |")
+        print()
+        print("_FP = false positives on no-match_")
+    else:
+        print(f"\n\n{'─'*84}")
+        print(f"  {title}")
+        print(f"  {'Engine':<36} {'Acc':>6} {'Prec':>6} {'Recall':>7} {'F1':>6}  "
+              f"{'FP':>4}  {'Median':>8}  {'Mean':>8}")
+        print(f"{'─'*84}")
+        for label, m, median_lat, mean_lat, train_ms in rows:
+            print(f"  {label:<36} {m['accuracy']:>5.1%} {m['precision']:>5.1%} "
+                  f"{m['recall']:>6.1%} {m['f1']:>5.3f}  {m['fp']:>4}  "
+                  f"{median_lat:>6.2f}ms  {mean_lat:>6.2f}ms")
+        print(f"{'─'*84}")
+        print("  FP = false positives on no-match | Median/Mean = query latency in ms")
+
+
+# ── main ───────────────────────────────────────────────────────────────────
+
+def run_dataset(name):
+    bundle = load(name)
+    cases = all_cases(bundle)
+    match_n = sum(1 for _, e in cases if e is not None)
+    print(f"\nDataset : {bundle.repo}  ({bundle.lang})")
+    print(f"Cases   : {len(cases)}  ({match_n} match, {len(cases)-match_n} no-match)")
+    print(f"Intents : {len(bundle.intents)}  across {len(bundle.domains)} domains")
+    print("Splits  : " + ", ".join(f"{k}={len(v)}" for k, v in bundle.splits.items()))
+
+    rows = []
+    # baselines
+    m, lat, mean_lat, tr = run_padaos(bundle, cases)
+    rows.append(("padaos", m, lat, mean_lat, tr))
+
+    m, lat, mean_lat, tr = run_nebulento(bundle, cases, threshold=0.5)
+    rows.append(("nebulento", m, lat, mean_lat, tr))
+
+    # subject — this repo's three engines
+    m, lat, mean_lat, tr = run_padatious_flat(bundle, cases, threshold=0.5)
+    rows.append(("padatious flat", m, lat, mean_lat, tr))
+
+    m, lat, mean_lat, tr = run_padatious_domain(bundle, cases, threshold=0.5)
+    rows.append(("padatious domain", m, lat, mean_lat, tr))
+
+    m, lat, mean_lat, tr = run_padatious_hierarchical(bundle, cases, threshold=0.5,
+                                                      domain_threshold=0.0)
+    rows.append(("padatious hierarchical", m, lat, mean_lat, tr))
+
+    summary(f"{name}  —  {bundle.repo}", rows)
+
+
+if __name__ == "__main__":
+    selected = [a for a in sys.argv[1:] if not a.startswith("-")]
+    targets = selected or list(DATASETS)
+    for dataset_name in targets:
+        if dataset_name not in DATASETS:
+            print(f"unknown dataset {dataset_name!r}; choose from {list(DATASETS)}")
+            continue
+        run_dataset(dataset_name)

--- a/benchmark/dataset.py
+++ b/benchmark/dataset.py
@@ -1,0 +1,108 @@
+"""Benchmark datasets — loaded from the Hugging Face Hub.
+
+Two OpenVoiceOS evaluation datasets are supported, both shaped the same way:
+a ``<lang>-templates`` config (training templates) and a ``<lang>-test`` config
+(labelled evaluation utterances).
+
+- ``intents-for-eval`` — ``OpenVoiceOS/intents-for-eval``. 50 intents, a test
+  set split into ``template`` / ``paraphrase`` / ``near_ood`` / ``asr_noise`` /
+  ``typos`` (labelled) and ``far_ood`` (no-match).
+- ``massive`` — ``OpenVoiceOS/massive-templates``, an OVOS-templated rebuild of
+  the MASSIVE intent corpus. ~60 intents, a single labelled test split, no
+  no-match cases.
+
+Every engine in this benchmark is a template / sample matcher, so it trains on
+the ``-templates`` config and is evaluated on the ``-test`` config.
+
+Slots are turned into entities: every ``{slot}`` placeholder carries example
+values, collected into ``Bundle.entities`` so engines can register them (the
+equivalent of a padatious ``.entity`` file) and fill the slot at match time.
+
+Usage::
+
+    from benchmark.dataset import load
+    bundle = load("intents-for-eval")        # or "massive"
+    bundle.intents      # {intent_id: {"train", "test_match", "entities", "domain"}}
+    bundle.entities     # {slot_name: [example_value, ...]}
+    bundle.domains      # {domain: [intent_id, ...]}
+    bundle.no_match     # [utterance, ...] that should match nothing
+    bundle.splits       # {split_name: [(utterance, expected_intent_or_None), ...]}
+"""
+from collections import defaultdict
+from typing import NamedTuple
+
+from datasets import load_dataset
+
+#: short name -> Hugging Face repo id
+DATASETS = {
+    "intents-for-eval": "OpenVoiceOS/intents-for-eval",
+    "massive": "OpenVoiceOS/massive-templates",
+}
+
+#: test splits whose utterances should match nothing
+_NOMATCH_SPLITS = ("far_ood",)
+
+
+class Bundle(NamedTuple):
+    """A loaded benchmark dataset."""
+    name: str
+    repo: str
+    lang: str
+    intents: dict
+    entities: dict
+    domains: dict
+    no_match: list
+    splits: dict
+
+
+def load(name: str = "intents-for-eval", lang: str = "en-US") -> Bundle:
+    """Load a benchmark dataset from the Hugging Face Hub.
+
+    Args:
+        name: One of :data:`DATASETS` (``intents-for-eval`` or ``massive``).
+        lang: BCP-47 language tag — the dataset's config prefix.
+
+    Returns:
+        A :class:`Bundle` with the templates grouped by intent and the test
+        utterances split into matches / no-matches.
+    """
+    repo = DATASETS[name]
+    templates = load_dataset(repo, f"{lang}-templates")["train"]
+    test = load_dataset(repo, f"{lang}-test")["test"]
+
+    intents: dict = {}
+    domains: dict = defaultdict(list)
+    entities: dict = defaultdict(list)
+    for row in templates:
+        iid = row["intent_id"]
+        if iid not in intents:
+            intents[iid] = {"train": [], "test_match": [],
+                            "entities": [], "domain": row["domain"]}
+            domains[row["domain"]].append(iid)
+        if row["template"] not in intents[iid]["train"]:
+            intents[iid]["train"].append(row["template"])
+        for slot in row["slots"] or []:
+            slot_name = slot["name"]
+            if slot_name not in intents[iid]["entities"]:
+                intents[iid]["entities"].append(slot_name)
+            for example in slot["examples"] or []:
+                if example not in entities[slot_name]:
+                    entities[slot_name].append(example)
+
+    no_match: list = []
+    splits: dict = defaultdict(list)
+    has_split = "split" in test.column_names
+    for row in test:
+        utt = row["utterance"]
+        expected = row["expected_intent"] or None
+        split = row["split"] if has_split else "test"
+        if split in _NOMATCH_SPLITS or expected is None:
+            no_match.append(utt)
+            splits[split].append((utt, None))
+        else:
+            if expected in intents:
+                intents[expected]["test_match"].append(utt)
+            splits[split].append((utt, expected))
+
+    return Bundle(name, repo, lang, intents, dict(entities), dict(domains),
+                  no_match, dict(splits))

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,8 +10,9 @@ This repository bundles a fork of the original [padatious](https://github.com/My
 |---|---|
 | [Installation](installation.md) | How to install dependencies and the package |
 | [Intent Format](intent_format.md) | Syntax for writing `.intent` and `.entity` files |
-| [API Reference](api_reference.md) | Python API for `IntentContainer` and `DomainIntentContainer` |
+| [API Reference](api_reference.md) | Python API for `IntentContainer`, `DomainIntentContainer`, and `HierarchicalIntentContainer` |
 | [OVOS Pipeline](ovos_pipeline.md) | Using the plugin inside OVOS / configuration options |
+| [Hierarchical Pipeline](hierarchical_pipeline.md) | Two-stage domain-routing pipeline variant |
 | [Architecture](architecture.md) | Internal architecture and data flow |
 | [Theory](theory.md) | Algorithm design, decisions, and limitations |
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,23 +1,51 @@
 # Benchmark
 
-`ovos-padatious-pipeline-plugin` ships a comparative accuracy and speed benchmark in `benchmark/compare.py`. It runs on two OpenVoiceOS evaluation datasets and reports every engine side by side.
+`ovos-padatious-pipeline-plugin` ships a comparative accuracy and speed benchmark in `benchmark/compare.py`. It runs on the OpenVoiceOS `intents-for-eval` evaluation dataset and reports the padatious engine — in all three variants (flat, per-domain parallel, hierarchical two-stage) — alongside a fixed set of external baselines, so results are directly comparable across the OVOS intent-engine family.
 
-Every OVOS intent engine ships the same benchmark — evaluated on the same two shared datasets against the same fixed baselines — so results are directly comparable across the whole engine family.
+---
+
+## Headline results — `intents-for-eval`
+
+50 intents across 10 domains, 1700 labelled test cases, 50 off-topic (`far_ood`) cases.
+
+| Engine | def F_0.5 | **opt F_0.5** | opt thr | opt FP | **Rec @ P≥99%** |
+|---|---|---|---|---|---|
+| **padatious flat** | 0.895 | **0.917** | 0.16 | 9 | **70.2%** |
+| padatious domain (parallel) | 0.898 | 0.900 | 0.38 | 16 | 65.4% |
+| padatious hierarchical (two-stage) | 0.887 | 0.892 | 0.39 | 4 | 63.2% |
+| nebulento `damerau` | 0.909 | 0.918 | 0.43 | 26 | 62.0% |
+| padaos (regex) | 0.662 (F1) | 0.662 (F1) | 0.50 | 1 | 0.0% (recall ≤ 50%) |
+
+**Padatious flat reaches F_0.5 = 0.917 once its threshold is calibrated — essentially tied with nebulento (0.918) and pulling ahead at the strict precision floor (R@P99 = 70.2% vs nebulento's 62.0%).** Among sample-matching engines on this dataset, padatious holds the highest recall while keeping precision at or above 99%.
+
+The shipped default threshold (0.5) is already close to F_0.5-optimal for every padatious variant: the calibration sweep moves F_0.5 by ≤ 0.03 points. This is the inverse of the Markov engine — padatious's defaults are well-chosen out of the box.
+
+---
+
+## Why F_0.5 and not F1
+
+A voice assistant's two failure modes are not symmetric:
+
+- **False positive** — the wrong intent fires, the skill executes the wrong action, the assistant says the wrong thing. The user has to notice, abort, and re-ask. There is no recovery layer above the intent service that can catch this.
+- **False negative** — no intent fires. OVOS hands the utterance to its fallback chain: common-query, the LLM fallback, online search. These exist precisely to handle "I don't know what you meant." Worst case the user re-phrases; best case the LLM nails it.
+
+The cost ratio is roughly 5–10× in favour of false negatives. F1 (which weights precision and recall equally) is the wrong summary metric. F_β with β=0.5 weights precision twice as recall and is the right summary for OVOS.
+
+We also report **Rec@P≥99%** — the recall achievable once the engine's threshold is tuned to keep precision at or above 99%. This is the operating point a maintainer actually picks: "give me the most coverage you can while letting through at most 1% wrong matches." Padatious flat at **70.2%** is the strongest sample-matching engine on this floor in the OVOS family today.
 
 ---
 
 ## Datasets
 
-Both datasets are loaded from the Hugging Face Hub by `benchmark/dataset.py`. Each has a `<lang>-templates` config (training templates) and a `<lang>-test` config (labelled evaluation utterances). Every engine in this benchmark is a template / sample matcher, so it trains on `-templates` and is evaluated on `-test`.
+The dataset is loaded from the Hugging Face Hub by `benchmark/dataset.py`. It has a `<lang>-templates` config (training templates) and a `<lang>-test` config (labelled evaluation utterances).
 
-| Name | Repo | Intents | Test cases | Notes |
+| Name | Repo | Intents | Domains | Test cases |
 |---|---|---|---|---|
-| `intents-for-eval` | [`OpenVoiceOS/intents-for-eval`](https://huggingface.co/datasets/OpenVoiceOS/intents-for-eval) | 50 | 1750 | Six test splits, including a `far_ood` no-match set |
-| `massive` | [`OpenVoiceOS/massive-templates`](https://huggingface.co/datasets/OpenVoiceOS/massive-templates) | 60 | 2974 | OVOS-templated rebuild of the MASSIVE corpus; one labelled split, no no-match cases |
+| `intents-for-eval` | [`OpenVoiceOS/intents-for-eval`](https://huggingface.co/datasets/OpenVoiceOS/intents-for-eval) | 50 | 10 | 1750 |
 
 `intents-for-eval` test splits:
 
-| Split | Cases | What it tests |
+| Split | Cases | Tests |
 |---|---|---|
 | `template` | 500 | Utterances that fill a training template directly |
 | `paraphrase` | 700 | Natural rephrasings — different words, same intent |
@@ -26,98 +54,149 @@ Both datasets are loaded from the Hugging Face Hub by `benchmark/dataset.py`. Ea
 | `asr_noise` | 50 | Speech-recognition artefacts |
 | `typos` | 50 | Spelling errors |
 
-`massive` has a single labelled `test` split and **no no-match cases** — so on `massive` every engine has zero false positives by construction, and accuracy equals recall.
+### Slots and entities
 
-### Entities
+Every `{slot}` placeholder in the templates ships with a list of example values. `benchmark/dataset.py` collects them into `Bundle.entities`.
 
-Each `{slot}` placeholder ships with example values. `benchmark/dataset.py` collects them into an entities map and every engine registers them (the equivalent of a padatious `.entity` file) before matching.
+- **padaos**, **padatious** and **nebulento** register the slot values as named entities natively (`add_entity` / `add_domain_entity`). Padatious's neural matcher then learns to associate the slot position with the entity vocabulary, so test queries containing real values (e.g. an actual song name in `play {song}`) still match.
+- For padatious domain and hierarchical, each entity is registered into every domain whose intents reference it — the benchmark walks `intent["entities"]` per intent to build the `domain → entities` map.
 
 ---
 
-## Engines Compared
+## Engines
 
-The benchmark separates fixed external **baselines** from the **subject** engines under test.
+The three `padatious` rows are the **subject** of this benchmark. `padaos` and `nebulento` are **fixed baselines** — the same engines and settings as in every OVOS intent-engine benchmark.
 
-| Engine | Role | Description |
+| Engine | Role | Notes |
 |---|---|---|
-| `padaos` | baseline | Regex-based exact matcher (no fuzzy) |
-| `nebulento` | baseline | Fuzzy string matching engine, default `damerau-levenshtein` strategy |
-| `padatious flat` | subject | This repo's flat neural `IntentContainer` |
-| `padatious domain` | subject | This repo's `DomainIntentContainer` — one container per domain, parallel argmax over domains |
-| `padatious hierarchical` | subject | This repo's `HierarchicalIntentContainer` — a top-level domain classifier routes the query, then the chosen domain's container resolves the intent |
+| `padaos` | baseline | regex-based exact matcher, no confidence knob |
+| `nebulento` | baseline | fuzzy string matcher, `DAMERAU_LEVENSHTEIN_SIMILARITY` |
+| `padatious flat` | subject | one neural `IntentContainer` over all 50 intents |
+| `padatious domain` (parallel) | subject | `DomainIntentContainer` — one neural net per domain, scored in parallel, global argmax |
+| `padatious hierarchical` (two-stage) | subject | `HierarchicalIntentContainer` — top-level domain classifier routes to the matching per-domain net |
 
-The three `padatious` rows are the subject of this benchmark; `padaos` and `nebulento` are the fixed baselines shared across every OVOS intent engine. padatious is itself one of the standard baselines — here it doubles as the subject, which is expected.
-
----
-
-## Results — `intents-for-eval`
-
-1750 cases (1700 match, 50 no-match), 50 intents across 10 domains.
-
-Run `python benchmark/compare.py intents-for-eval` to produce this table. The full run trains five engines, three of which require a neural training pass — it is slow. Results are not committed here; fill the table from a local run.
-
-| Engine | Accuracy | Precision | Recall | F1 | FP / 50 | Median lat |
-|---|---|---|---|---|---|---|
-| padaos | _run_ | _run_ | _run_ | _run_ | _run_ | _run_ |
-| nebulento | _run_ | _run_ | _run_ | _run_ | _run_ | _run_ |
-| padatious flat | _run_ | _run_ | _run_ | _run_ | _run_ | _run_ |
-| padatious domain | _run_ | _run_ | _run_ | _run_ | _run_ | _run_ |
-| padatious hierarchical | _run_ | _run_ | _run_ | _run_ | _run_ | _run_ |
-
-FP = false positives on the 50 `far_ood` no-match utterances. Latency varies run-to-run.
+All three padatious variants require a `train()` step. Training time and per-query latency are recorded in each per-engine report.
 
 ---
 
-## Results — `massive`
+## Deep-dive: tuning padatious
 
-2974 cases, 60 intents across 18 domains. The corpus has no no-match cases, so false positives are zero for every engine and accuracy equals recall — this dataset measures recall on a broad, diverse intent set.
+### 1. Defaults are well-tuned
 
-Run it with `python benchmark/compare.py massive`. The summary table has the same columns as above; because `massive` has no off-topic split, the `FP` column is zero for every engine and `Accuracy` equals `Recall`.
+The most striking finding: padatious's shipped default threshold (0.5) and default neural configuration are essentially F_0.5-optimal on this dataset.
+
+| Variant | def F_0.5 | opt F_0.5 | Δ |
+|---|---|---|---|
+| padatious flat | 0.895 | 0.917 | +0.022 |
+| padatious domain | 0.898 | 0.900 | +0.002 |
+| padatious hierarchical | 0.887 | 0.892 | +0.005 |
+
+Compared to the Markov engine on the same dataset (def F_0.5 = 0.665, opt F_0.5 = 0.909 — a +0.244 swing from calibration alone), padatious arrives operationally ready. The neural network produces well-calibrated confidences: the conf distribution has a clear separation between true matches and noise, and 0.5 sits roughly at that boundary.
+
+Flat does benefit slightly from a lower threshold (0.16 vs 0.50): the network's confidence for correct matches sometimes dips below 0.5 on paraphrases and ASR-noise inputs, and the false-positive surface remains small even when the threshold drops. Domain and hierarchical's optimal thresholds stay near the default (0.38–0.39) because their per-domain nets are more confident inside their own scope.
+
+### 2. Per-domain training: does it help?
+
+Yes — marginally on F_0.5, but with operational benefits beyond pure accuracy.
+
+| Variant | opt F_0.5 | opt FP | R@P99 | Train ms | Median ms |
+|---|---|---|---|---|---|
+| padatious flat | **0.917** | 9 | **70.2%** | 13 158 | 6.17 |
+| padatious domain | 0.900 | 16 | 65.4% | 3 688 | 14.14 |
+| padatious hierarchical | 0.892 | 4 | 63.2% | 58 908 | 13.19 |
+
+Each domain in `DomainIntentContainer` trains its own neural net against per-domain negatives (the other intents in that domain). This is fundamentally different from flat training, where a single net must learn to discriminate all 50 intents simultaneously. Two consequences:
+
+- **Domain trains 3.6× faster than flat** (3.7 s vs 13.2 s). Each per-domain net only has ~5 intents to discriminate, so each net's training surface is much smaller; even running 10 nets, total wall-time wins.
+- **Domain loses 1.7 points of opt F_0.5 vs flat** (0.900 vs 0.917). When confidences from 10 independent nets are compared, calibration drift across nets shows up: a net trained on a low-variance domain (e.g. `timers_alarms`) produces sharper, higher confidences than one trained on a noisy domain (e.g. `search_qa`), so the global argmax is noisier than a single flat net's argmax.
+
+Domain's FP count rises (16 vs flat's 9) because each net votes inside its own domain regardless of how off-topic the utterance is — there is no shared "this isn't anything" signal.
+
+### 3. Hierarchical: routing cost vs precision
+
+`HierarchicalIntentContainer` adds a top-level domain classifier on top of the per-domain nets. On this dataset it is the weakest variant by F_0.5 (0.892), but it produces the **lowest FP count** (4 — tied with flat at default threshold) and pays the highest training cost (58.9 s — 4.5× the flat baseline, 16× the domain baseline).
+
+The trade-off:
+
+- **Why FP is so low**: an off-topic utterance has to first pass the domain classifier, *then* clear the per-domain intent threshold. Two filters compound. Each fires for a different reason, so false positives that slip through one rarely slip through both.
+- **Why recall (and F_0.5) drops**: the domain classifier is itself a sample matcher. If it picks the wrong domain for a borderline utterance (e.g. routing "set my morning alarm to 7" to `calendar` instead of `timers_alarms`), the correct intent is never even scored. This routing cost shows up as roughly 2 points of opt F_0.5 vs flat.
+- **Why training is so slow**: the domain classifier itself needs to be trained on the union of every intent's templates as labelled-by-domain examples — that's the full 50-intent training surface again, on top of the 10 per-domain nets. So hierarchical pays the flat training cost *plus* the domain training cost.
+
+Hierarchical is the right pick when (a) you need the strictest possible FP floor and (b) per-skill modular retraining matters more than throughput. It is not the right default.
+
+### 4. Where padatious wins
+
+- **R@P99 = 70.2% (flat).** No other sample-matching engine in the OVOS family currently exceeds this on `intents-for-eval`. Padatious's neural calibration means the confidence threshold can be tightened to keep precision ≥ 99% while still recovering 70% of legitimate matches. Nebulento tops out at 62.0%, the Markov engine at 59.5%. For a production OVOS install where "wrong action" is the dominant failure cost, padatious flat is the safest choice.
+- **Zero or very low FP at default threshold.** Flat returns 4 FP at threshold 0.5; hierarchical returns 4; domain returns 6. This is consistently among the lowest in the engine family before any tuning.
+- **Precision is ≥ 99% across all three variants** at the default threshold (99.5%–99.6%). The neural net is conservative by construction: it returns no match when no learned template is close enough.
+
+### 5. Where padatious loses
+
+- **Ceiling: recall caps near 64%.** At default threshold, padatious flat recovers only 63.7% of match cases. Looking at the per-intent breakdown (60+ intents with recall below 75%), the bottleneck is template coverage: with ~10–20 training templates per intent, the neural net has not seen enough lexical variation to handle the full `paraphrase` and `asr_noise` splits. Nebulento's edit-distance scoring is more forgiving of minor word swaps, which is why it edges flat at opt F_0.5 (0.918 vs 0.917).
+- **Latency: 6–14 ms per query.** Padaos runs at 0.30 ms — 20× faster. For low-power devices or high-QPS routing, the regex baseline still wins on speed.
+- **Training time: 13–59 seconds.** Padaos compiles in 305 ms. If your deployment retrains on every skill load, padatious is in another order of magnitude. The domain variant softens this (3.7 s) at a small accuracy cost.
 
 ---
 
-## How to Run
+## Flat vs Domain vs Hierarchical (for padatious)
 
-Install benchmark dependencies:
+After running each variant at its F_0.5-optimal threshold:
+
+| Variant | opt F_0.5 | opt FP | R@P99 | Train s | Median ms |
+|---|---|---|---|---|---|
+| **padatious flat** | **0.917** | 9 | **70.2%** | 13.2 | 6.17 |
+| padatious domain (parallel) | 0.900 | 16 | 65.4% | **3.7** | 14.14 |
+| padatious hierarchical (two-stage) | 0.892 | 4 | 63.2% | 58.9 | 13.19 |
+
+Unlike a pure sample-matcher (where flat/domain/hierarchical are essentially the same model partitioned differently), padatious legitimately ships all three because each variant trains a *different* neural model:
+
+- **Flat** trains one net against all 50 intents as competing classes — maximum cross-intent discrimination, slowest single-net training.
+- **Domain (parallel)** trains 10 small nets, each discriminating only the 5-or-so intents in its domain. Faster training, smaller per-net surface, looser cross-domain calibration.
+- **Hierarchical** adds a routing net on top. Lowest FP, highest training cost, lowest peak F_0.5 due to routing errors.
+
+**Recommendation for OVOS deployments:**
+
+- **Default**: `padatious flat`. Highest F_0.5, highest R@P99, moderate training time, lowest median latency.
+- **Modular / per-skill retraining**: `padatious domain`. Pay 1.7 points of F_0.5 to get 3.6× faster training and the ability to retrain a single domain in isolation.
+- **Strictest FP floor**: `padatious hierarchical`. Pay 2.5 points of F_0.5 (and 4.5× training time) for the two-stage filter.
+
+For most installs the flat engine is the sensible default; domain and hierarchical are worth picking when modularity or precision dominance outweigh the F_0.5 cost.
+
+---
+
+## Reproducing
 
 ```bash
-pip install ovos-padatious[benchmark]
-# installs: padaos, nebulento, datasets, fann2==1.0.7
+pip install ovos-padatious-pipeline-plugin[benchmark]
+python benchmark/compare.py intents-for-eval   # ~2 minutes
 ```
 
-Run both datasets:
+The first run downloads the dataset from the Hugging Face Hub (cached afterwards).
+
+To re-run the calibration from scratch:
 
 ```bash
-python benchmark/compare.py
-```
-
-Or one at a time:
-
-```bash
+rm -rf ~/.cache/huggingface/datasets/OpenVoiceOS___intents-for-eval \
+       ~/.cache/huggingface/hub/datasets--OpenVoiceOS--intents-for-eval
 python benchmark/compare.py intents-for-eval
-python benchmark/compare.py massive
 ```
 
-The first run downloads each dataset from the Hugging Face Hub (cached afterwards). The three padatious engines each require a training pass; `padaos` and `nebulento` start immediately. Pass `--ci` for collapsible Markdown output suitable for a CI job summary.
+The script prints a per-engine report, a summary table, and a calibration table sweeping the threshold from 0 to 1 in 0.01 steps to find the F_0.5-optimum and the Rec@P≥99% operating point for every engine that exposes a confidence score.
 
 ---
 
-## How Metrics Are Calculated
+## How metrics are calculated
 
-Source: `compute_metrics` in `benchmark/compare.py`.
+Source: `compute_metrics`, `calibrate_threshold`, `fbeta`, `recall_at_precision` in `benchmark/compare.py`.
 
 - **Accuracy** = (TP + TN) / total
 - **Precision** = TP / (TP + FP)
 - **Recall** = TP / total_match_cases
-- **F1** = 2 × precision × recall / (precision + recall)
+- **F1** = 2·P·R / (P + R)
+- **F_0.5** = 1.25·P·R / (0.25·P + R) — weights precision 2× recall (default summary metric for OVOS)
+- **Rec@P≥99%** = max recall achievable by sweeping the threshold while keeping precision ≥ 99%
 - **FP** = no-match utterances incorrectly assigned an intent
 
-A prediction is a TP when the predicted intent name exactly matches the expected intent and `conf >= threshold` (0.5). A no-match case is correct only when the engine returns `None` or a confidence below threshold.
+A prediction is a TP when the predicted intent name exactly matches the expected intent and `conf ≥ threshold`. A no-match case is correct only when the engine returns `None` or a confidence below threshold.
 
----
-
-## The Three padatious Engines
-
-- **`padatious flat`** — the standard `IntentContainer`. Every intent is scored in a single flat namespace.
-- **`padatious domain`** — `DomainIntentContainer` gives each domain its own `IntentContainer` and takes the global argmax over all domains' top-1 matches. There is no router; parallel scoring keeps confidences comparable.
-- **`padatious hierarchical`** — `HierarchicalIntentContainer` is two-stage: a top-level classifier picks one domain, then only that domain's container resolves the intent. With `domain_threshold` raised above `0.0`, the classifier also gates off-topic queries before any intent is scored. The benchmark runs it with `domain_threshold=0.0` (no gate) to isolate the cost of misrouting.
+The calibration sweep re-applies the threshold to the engine's raw `(label, conf)` outputs rather than re-running the engine — every engine's runner returns the unthresholded `raw` list so calibration is a pure post-processing step.

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,0 +1,123 @@
+# Benchmark
+
+`ovos-padatious-pipeline-plugin` ships a comparative accuracy and speed benchmark in `benchmark/compare.py`. It runs on two OpenVoiceOS evaluation datasets and reports every engine side by side.
+
+Every OVOS intent engine ships the same benchmark — evaluated on the same two shared datasets against the same fixed baselines — so results are directly comparable across the whole engine family.
+
+---
+
+## Datasets
+
+Both datasets are loaded from the Hugging Face Hub by `benchmark/dataset.py`. Each has a `<lang>-templates` config (training templates) and a `<lang>-test` config (labelled evaluation utterances). Every engine in this benchmark is a template / sample matcher, so it trains on `-templates` and is evaluated on `-test`.
+
+| Name | Repo | Intents | Test cases | Notes |
+|---|---|---|---|---|
+| `intents-for-eval` | [`OpenVoiceOS/intents-for-eval`](https://huggingface.co/datasets/OpenVoiceOS/intents-for-eval) | 50 | 1750 | Six test splits, including a `far_ood` no-match set |
+| `massive` | [`OpenVoiceOS/massive-templates`](https://huggingface.co/datasets/OpenVoiceOS/massive-templates) | 60 | 2974 | OVOS-templated rebuild of the MASSIVE corpus; one labelled split, no no-match cases |
+
+`intents-for-eval` test splits:
+
+| Split | Cases | What it tests |
+|---|---|---|
+| `template` | 500 | Utterances that fill a training template directly |
+| `paraphrase` | 700 | Natural rephrasings — different words, same intent |
+| `near_ood` | 400 | Boundary utterances close to another intent |
+| `far_ood` | 50 | Genuinely off-topic — should match **nothing** |
+| `asr_noise` | 50 | Speech-recognition artefacts |
+| `typos` | 50 | Spelling errors |
+
+`massive` has a single labelled `test` split and **no no-match cases** — so on `massive` every engine has zero false positives by construction, and accuracy equals recall.
+
+### Entities
+
+Each `{slot}` placeholder ships with example values. `benchmark/dataset.py` collects them into an entities map and every engine registers them (the equivalent of a padatious `.entity` file) before matching.
+
+---
+
+## Engines Compared
+
+The benchmark separates fixed external **baselines** from the **subject** engines under test.
+
+| Engine | Role | Description |
+|---|---|---|
+| `padaos` | baseline | Regex-based exact matcher (no fuzzy) |
+| `nebulento` | baseline | Fuzzy string matching engine, default `damerau-levenshtein` strategy |
+| `padatious flat` | subject | This repo's flat neural `IntentContainer` |
+| `padatious domain` | subject | This repo's `DomainIntentContainer` — one container per domain, parallel argmax over domains |
+| `padatious hierarchical` | subject | This repo's `HierarchicalIntentContainer` — a top-level domain classifier routes the query, then the chosen domain's container resolves the intent |
+
+The three `padatious` rows are the subject of this benchmark; `padaos` and `nebulento` are the fixed baselines shared across every OVOS intent engine. padatious is itself one of the standard baselines — here it doubles as the subject, which is expected.
+
+---
+
+## Results — `intents-for-eval`
+
+1750 cases (1700 match, 50 no-match), 50 intents across 10 domains.
+
+Run `python benchmark/compare.py intents-for-eval` to produce this table. The full run trains five engines, three of which require a neural training pass — it is slow. Results are not committed here; fill the table from a local run.
+
+| Engine | Accuracy | Precision | Recall | F1 | FP / 50 | Median lat |
+|---|---|---|---|---|---|---|
+| padaos | _run_ | _run_ | _run_ | _run_ | _run_ | _run_ |
+| nebulento | _run_ | _run_ | _run_ | _run_ | _run_ | _run_ |
+| padatious flat | _run_ | _run_ | _run_ | _run_ | _run_ | _run_ |
+| padatious domain | _run_ | _run_ | _run_ | _run_ | _run_ | _run_ |
+| padatious hierarchical | _run_ | _run_ | _run_ | _run_ | _run_ | _run_ |
+
+FP = false positives on the 50 `far_ood` no-match utterances. Latency varies run-to-run.
+
+---
+
+## Results — `massive`
+
+2974 cases, 60 intents across 18 domains. The corpus has no no-match cases, so false positives are zero for every engine and accuracy equals recall — this dataset measures recall on a broad, diverse intent set.
+
+Run it with `python benchmark/compare.py massive`. The summary table has the same columns as above; because `massive` has no off-topic split, the `FP` column is zero for every engine and `Accuracy` equals `Recall`.
+
+---
+
+## How to Run
+
+Install benchmark dependencies:
+
+```bash
+pip install ovos-padatious[benchmark]
+# installs: padaos, nebulento, datasets, fann2==1.0.7
+```
+
+Run both datasets:
+
+```bash
+python benchmark/compare.py
+```
+
+Or one at a time:
+
+```bash
+python benchmark/compare.py intents-for-eval
+python benchmark/compare.py massive
+```
+
+The first run downloads each dataset from the Hugging Face Hub (cached afterwards). The three padatious engines each require a training pass; `padaos` and `nebulento` start immediately. Pass `--ci` for collapsible Markdown output suitable for a CI job summary.
+
+---
+
+## How Metrics Are Calculated
+
+Source: `compute_metrics` in `benchmark/compare.py`.
+
+- **Accuracy** = (TP + TN) / total
+- **Precision** = TP / (TP + FP)
+- **Recall** = TP / total_match_cases
+- **F1** = 2 × precision × recall / (precision + recall)
+- **FP** = no-match utterances incorrectly assigned an intent
+
+A prediction is a TP when the predicted intent name exactly matches the expected intent and `conf >= threshold` (0.5). A no-match case is correct only when the engine returns `None` or a confidence below threshold.
+
+---
+
+## The Three padatious Engines
+
+- **`padatious flat`** — the standard `IntentContainer`. Every intent is scored in a single flat namespace.
+- **`padatious domain`** — `DomainIntentContainer` gives each domain its own `IntentContainer` and takes the global argmax over all domains' top-1 matches. There is no router; parallel scoring keeps confidences comparable.
+- **`padatious hierarchical`** — `HierarchicalIntentContainer` is two-stage: a top-level classifier picks one domain, then only that domain's container resolves the intent. With `domain_threshold` raised above `0.0`, the classifier also gates off-topic queries before any intent is scored. The benchmark runs it with `domain_threshold=0.0` (no gate) to isolate the cost of misrouting.

--- a/docs/hierarchical_pipeline.md
+++ b/docs/hierarchical_pipeline.md
@@ -1,0 +1,64 @@
+# Hierarchical Pipeline Plugin
+
+`HierarchicalPadatiousPipeline` is a two-stage variant of the Padatious pipeline. Intents are grouped into domains; a top-level classifier first selects a single domain, and only that domain's intents are scored to resolve the final intent.
+
+## Intent-Matching Variants
+
+The plugin ships three OPM pipeline entry points, all discovered automatically by OVOS:
+
+| Entry point | Container | Strategy |
+|---|---|---|
+| `ovos-padatious-pipeline-plugin` | `IntentContainer` | **flat** — every intent is scored globally |
+| `ovos-padatious-domain-pipeline-plugin` | `DomainIntentContainer` | **Domain (parallel)** — all domains are scored, global argmax wins |
+| `ovos-padatious-hierarchical-pipeline-plugin` | `HierarchicalIntentContainer` | **Hierarchical (two-stage)** — a classifier picks one domain, then only that domain is scored |
+
+In every variant the `skill_id` of a registered intent becomes its domain.
+
+## How Two-Stage Routing Works
+
+1. **Domain classification** — a top-level `IntentContainer` is trained with each domain name as a label over the union of that domain's intent samples. At query time it predicts the most likely domain.
+2. **Intent resolution** — only the predicted domain's sub-container scores the utterance; its best intent is returned.
+
+The top-level classifier is rebuilt lazily: registering intents only marks a domain stale, and the classifier is retrained on the next `train()` call. This keeps bulk registration linear.
+
+A domain can also be supplied explicitly to `calc_intent`, which bypasses the classifier and the threshold gate.
+
+## Configuration
+
+Configuration lives under `intents.ovos-padatious-hierarchical-pipeline-plugin` (or `padatious_hierarchical`):
+
+```json
+{
+  "intents": {
+    "ovos-padatious-hierarchical-pipeline-plugin": {
+      "conf_high": 0.95,
+      "conf_med": 0.8,
+      "conf_low": 0.5,
+      "domain_threshold": 0.0,
+      "instant_train": false,
+      "intent_cache": "~/.local/share/mycroft/intent_cache",
+      "disable_padaos": false,
+      "cast_to_ascii": false,
+      "stem": false
+    }
+  }
+}
+```
+
+The pipeline accepts every key the flat pipeline does (see [OVOS Pipeline](ovos_pipeline.md)), plus:
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `domain_threshold` | `float` | `0.0` | Minimum confidence the top-level classifier must reach for a query to be routed. When the best domain scores below this, the query is rejected before any sub-container runs. `0.0` disables the gate. |
+
+The cache path is suffixed with `_hierarchical` so this variant's trained models do not collide with the flat or Domain caches.
+
+## When to Use
+
+- **Flat** — small intent sets where global scoring is cheap.
+- **Domain (parallel)** — many domains, but per-domain confidences are comparable and a global argmax is acceptable.
+- **Hierarchical (two-stage)** — large intent sets where a fast top-level classifier narrows the search, and `domain_threshold` can reject off-topic utterances early.
+
+## Messagebus Events
+
+The hierarchical pipeline subscribes to and emits the same messagebus events as the flat pipeline. See [OVOS Pipeline](ovos_pipeline.md#messagebus-events).

--- a/docs/ovos_pipeline.md
+++ b/docs/ovos_pipeline.md
@@ -4,15 +4,17 @@
 
 ## Entry Points
 
-The plugin ships two OPM pipeline entry points, both discovered automatically by OVOS:
+The plugin ships three OPM pipeline entry points, all discovered automatically by OVOS:
 
 ```
-ovos-padatious-pipeline-plugin         = ovos_padatious.opm:PadatiousPipeline
-ovos-padatious-domain-pipeline-plugin  = ovos_padatious.opm:DomainPadatiousPipeline
+ovos-padatious-pipeline-plugin               = ovos_padatious.opm:PadatiousPipeline
+ovos-padatious-domain-pipeline-plugin        = ovos_padatious.opm:DomainPadatiousPipeline
+ovos-padatious-hierarchical-pipeline-plugin  = ovos_padatious.opm:HierarchicalPadatiousPipeline
 ```
 
 - `ovos-padatious-pipeline-plugin` — the flat pipeline backed by `IntentContainer`.
 - `ovos-padatious-domain-pipeline-plugin` — backed by `DomainIntentContainer`. The `skill_id` of each registered intent becomes its domain; all sub-domains score the query in parallel and the global best wins. Configuration lives under `intents.ovos-padatious-domain-pipeline-plugin` (or `padatious_domain`).
+- `ovos-padatious-hierarchical-pipeline-plugin` — backed by `HierarchicalIntentContainer`. A top-level classifier picks one domain, then only that domain's intents are scored. See [Hierarchical Pipeline](hierarchical_pipeline.md).
 
 > The legacy `domain_engine: true` config flag on the flat pipeline still works for backward compatibility, but is **deprecated**. Select `ovos-padatious-domain-pipeline-plugin` at the pipeline level instead.
 

--- a/docs/ovos_pipeline.md
+++ b/docs/ovos_pipeline.md
@@ -2,13 +2,19 @@
 
 `PadatiousPipeline` integrates Padatious as a confidence-based intent matcher in the OVOS pipeline system.
 
-## Entry Point
+## Entry Points
 
-The plugin is registered via `setup.py` / `setup.cfg` entry points and discovered automatically by OVOS.
+The plugin ships two OPM pipeline entry points, both discovered automatically by OVOS:
 
 ```
-ovos.pipeline.padatious = ovos_padatious.opm:PadatiousPipeline
+ovos-padatious-pipeline-plugin         = ovos_padatious.opm:PadatiousPipeline
+ovos-padatious-domain-pipeline-plugin  = ovos_padatious.opm:DomainPadatiousPipeline
 ```
+
+- `ovos-padatious-pipeline-plugin` — the flat pipeline backed by `IntentContainer`.
+- `ovos-padatious-domain-pipeline-plugin` — backed by `DomainIntentContainer`. The `skill_id` of each registered intent becomes its domain; all sub-domains score the query in parallel and the global best wins. Configuration lives under `intents.ovos-padatious-domain-pipeline-plugin` (or `padatious_domain`).
+
+> The legacy `domain_engine: true` config flag on the flat pipeline still works for backward compatibility, but is **deprecated**. Select `ovos-padatious-domain-pipeline-plugin` at the pipeline level instead.
 
 ## Configuration
 
@@ -39,7 +45,7 @@ Place configuration under `"intent_boxes"` → `"ovos-padatious-pipeline-plugin"
 | `conf_high` | `float` | `0.95` | Minimum confidence for `match_high`. |
 | `conf_med` | `float` | `0.80` | Minimum confidence for `match_medium`. |
 | `conf_low` | `float` | `0.50` | Minimum confidence for `match_low`. |
-| `domain_engine` | `bool` | `false` | Use `DomainIntentContainer` instead of `IntentContainer`. Groups intents by skill for faster disambiguation. |
+| `domain_engine` | `bool` | `false` | **Deprecated** — select the `ovos-padatious-domain-pipeline-plugin` entry point instead. Kept for backward compatibility; when `true` forces the flat pipeline to use `DomainIntentContainer`. |
 | `instant_train` | `bool` | `false` | Trigger training immediately after each intent registration instead of waiting for the `mycroft.skills.train` bus event. |
 | `intent_cache` | `str` | XDG data home | Override the directory where trained models are cached. |
 | `disable_padaos` | `bool` | `false` | Disable the fast regex exact-match layer (padaos). Only the neural network is used. |

--- a/ovos_padatious/domain_container.py
+++ b/ovos_padatious/domain_container.py
@@ -139,43 +139,74 @@ class DomainIntentContainer:
 
     def calc_intent(self, query: str, domain: Optional[str] = None) -> MatchData:
         """
-        Calculate the best matching intent for a query within a specific domain.
+        Calculate the best matching intent for a query.
+
+        By default this follows the adapt-style parallel-argmax pattern:
+        every sub-domain container scores the query and the single highest
+        confidence intent wins globally. The legacy two-stage routing via
+        the top-level ``domain_engine`` is no longer used by default — that
+        engine remains trained for callers of :meth:`calc_domain`/
+        :meth:`calc_domains` but does not gate intent selection.
 
         Args:
             query (str): The input query.
-            domain (Optional[str]): The domain to limit the search to. Defaults to None.
+            domain (Optional[str]): If given, restrict matching to this domain.
 
         Returns:
-            MatchData: The best matching intent.
-        """
-        if self.must_train:
-            self.train()
-        domain: str = domain or self.domain_engine.calc_intent(query).name
-        if domain in self.domains:
-            return self.domains[domain].calc_intent(query)
-        return MatchData(name=None, sent=query, matches=None, conf=0.0)
-
-    def calc_intents(self, query: str, domain: Optional[str] = None, top_k_domains: int = 2) -> List[MatchData]:
-        """
-        Calculate matching intents for a query across domains or within a specific domain.
-
-        Args:
-            query (str): The input query.
-            domain (Optional[str]): The specific domain to search in. If None, searches across top-k domains.
-            top_k_domains (int): The number of top domains to consider. Defaults to 2.
-
-        Returns:
-            List[MatchData]: A list of MatchData objects representing matching intents, sorted by confidence.
+            MatchData: The best matching intent across all domains (or
+            within the given domain).
         """
         if self.must_train:
             self.train()
         if domain:
-            return self.domains[domain].calc_intents(query)
-        matches = []
-        domains = self.calc_domains(query)[:top_k_domains]
-        for domain in domains:
-            if domain.name in self.domains:
-                matches += self.domains[domain.name].calc_intents(query)
+            if domain in self.domains:
+                return self.domains[domain].calc_intent(query)
+            return MatchData(name=None, sent=query, matches=None, conf=0.0)
+        matches = self.calc_intents(query)
+        if matches:
+            return matches[0]
+        return MatchData(name=None, sent=query, matches=None, conf=0.0)
+
+    def calc_intents(self, query: str, domain: Optional[str] = None,
+                     top_k_domains: Optional[int] = None) -> List[MatchData]:
+        """
+        Calculate matching intents for a query across domains.
+
+        Default behaviour is to score the query against every sub-domain
+        container in parallel and flatten the results (adapt-style
+        parallel argmax). ``top_k_domains`` is kept as an opt-in
+        optimisation hint: when set, the cheap domain-fingerprint engine
+        is consulted first and only the union of the top-K domains'
+        intents is scored.
+
+        Args:
+            query (str): The input query.
+            domain (Optional[str]): The specific domain to search in.
+                When given, ``top_k_domains`` is ignored.
+            top_k_domains (Optional[int]): Optional optimisation. When
+                set to a positive integer, restrict scoring to the top-K
+                domains as ranked by the top-level domain engine.
+                Defaults to None (score every domain).
+
+        Returns:
+            List[MatchData]: MatchData objects sorted by confidence (desc).
+        """
+        if self.must_train:
+            self.train()
+        if domain:
+            if domain in self.domains:
+                return self.domains[domain].calc_intents(query)
+            return []
+
+        if top_k_domains and top_k_domains > 0:
+            ranked = self.calc_domains(query)[:top_k_domains]
+            domain_names = [d.name for d in ranked if d.name in self.domains]
+        else:
+            domain_names = list(self.domains.keys())
+
+        matches: List[MatchData] = []
+        for name in domain_names:
+            matches += self.domains[name].calc_intents(query)
         return sorted(matches, reverse=True, key=lambda k: k.conf)
 
     def train(self):

--- a/ovos_padatious/domain_container.py
+++ b/ovos_padatious/domain_container.py
@@ -1,220 +1,106 @@
-from collections import defaultdict
+"""Domain-aware intent container.
+
+Each domain owns an :class:`IntentContainer`. At query time every
+container scores the utterance independently; the highest-confidence
+intent across the union wins. There is no top-level router — parallel
+scoring is cheap and each container's confidence is comparable.
+"""
 from typing import Dict, List, Optional
+
 from ovos_utils.log import LOG
+
 from ovos_padatious.intent_container import IntentContainer
 from ovos_padatious.match_data import MatchData
 
 
 class DomainIntentContainer:
-    """
-    A domain-aware intent recognition engine that organizes intents and entities
-    into specific domains, providing flexible and hierarchical intent matching.
-    """
+    """Per-domain :class:`IntentContainer` with parallel argmax over domains."""
 
-    def __init__(self, cache_dir: Optional[str] = None, disable_padaos: bool = False):
-        """
-        Initialize the DomainIntentEngine.
-
-        Attributes:
-            domain_engine (IntentContainer): A top-level intent container for cross-domain calculations.
-            domains (Dict[str, IntentContainer]): A mapping of domain names to their respective intent containers.
-            training_data (Dict[str, List[str]]): A mapping of domain names to their associated training samples.
-        """
+    def __init__(self, cache_dir: Optional[str] = None,
+                 disable_padaos: bool = False):
         self.cache_dir = cache_dir
         self.disable_padaos = disable_padaos
-        self.domain_engine = IntentContainer(cache_dir=cache_dir,
-                                             disable_padaos=disable_padaos)
         self.domains: Dict[str, IntentContainer] = {}
-        self.training_data: Dict[str, List[str]] = defaultdict(list)
-        self.instantiate_from_disk()
         self.must_train = True
 
-    def instantiate_from_disk(self) -> None:
-        """
-        Instantiates the necessary (internal) data structures when loading persisted model from disk.
-        This is done via injecting entities and intents back from cached file versions.
-        """
-        self.domain_engine.instantiate_from_disk()
-        for engine in self.domains.values():
-            engine.instantiate_from_disk()
+    # ── domain management ──────────────────────────────────────────────
 
-    def remove_domain(self, domain_name: str):
-        """
-        Remove a domain and its associated intents and training data.
+    def remove_domain(self, domain_name: str) -> None:
+        self.domains.pop(domain_name, None)
 
-        Args:
-            domain_name (str): The name of the domain to remove.
-        """
-        if domain_name in self.training_data:
-            self.training_data.pop(domain_name)
-        if domain_name in self.domains:
-            self.domains.pop(domain_name)
-        if domain_name in self.domain_engine.intent_names:
-            self.domain_engine.remove_intent(domain_name)
+    # ── intent management ──────────────────────────────────────────────
 
-    def add_domain_intent(self, domain_name: str, intent_name: str, intent_samples: List[str],
-                          blacklisted_words: Optional[List[str]] = None):
-        """
-        Register an intent within a specific domain.
-
-        Args:
-            domain_name (str): The name of the domain.
-            intent_name (str): The name of the intent to register.
-            intent_samples (List[str]): A list of sample sentences for the intent.
-        """
-        if domain_name not in self.domains:
-            self.domains[domain_name] = IntentContainer(cache_dir=self.cache_dir,
-                                                        disable_padaos=self.disable_padaos)
-            self.domains[domain_name].instantiate_from_disk()
-
-        self.domains[domain_name].add_intent(intent_name, intent_samples,
-                                             blacklisted_words=blacklisted_words)
-        self.training_data[domain_name] += intent_samples
+    def add_domain_intent(self, domain_name: str, intent_name: str,
+                          intent_samples: List[str],
+                          blacklisted_words: Optional[List[str]] = None) -> None:
+        self._get_container(domain_name).add_intent(
+            intent_name, intent_samples,
+            blacklisted_words=blacklisted_words,
+        )
         self.must_train = True
 
-    def remove_domain_intent(self, domain_name: str, intent_name: str):
-        """
-        Remove a specific intent from a domain.
-
-        Args:
-            domain_name (str): The name of the domain.
-            intent_name (str): The name of the intent to remove.
-        """
+    def remove_domain_intent(self, domain_name: str, intent_name: str) -> None:
         if domain_name in self.domains:
             self.domains[domain_name].remove_intent(intent_name)
 
-    def add_domain_entity(self, domain_name: str, entity_name: str, entity_samples: List[str]):
-        """
-        Register an entity within a specific domain.
+    # ── entity management ──────────────────────────────────────────────
 
-        Args:
-            domain_name (str): The name of the domain.
-            entity_name (str): The name of the entity to register.
-            entity_samples (List[str]): A list of sample phrases for the entity.
-        """
-        if domain_name not in self.domains:
-            self.domains[domain_name] = IntentContainer(cache_dir=self.cache_dir,
-                                                        disable_padaos=self.disable_padaos)
-        self.domains[domain_name].add_entity(entity_name, entity_samples)
+    def add_domain_entity(self, domain_name: str, entity_name: str,
+                          entity_samples: List[str]) -> None:
+        self._get_container(domain_name).add_entity(entity_name, entity_samples)
 
-    def remove_domain_entity(self, domain_name: str, entity_name: str):
-        """
-        Remove a specific entity from a domain.
-
-        Args:
-            domain_name (str): The name of the domain.
-            entity_name (str): The name of the entity to remove.
-        """
+    def remove_domain_entity(self, domain_name: str, entity_name: str) -> None:
         if domain_name in self.domains:
             self.domains[domain_name].remove_entity(entity_name)
 
-    def calc_domains(self, query: str) -> List[MatchData]:
-        """
-        Calculate the matching domains for a query.
+    # ── matching ───────────────────────────────────────────────────────
 
-        Args:
-            query (str): The input query.
+    def calc_intent(self, query: str,
+                     domain: Optional[str] = None) -> MatchData:
+        """Return the best intent match across all domains.
 
-        Returns:
-            List[MatchData]: A list of MatchData objects representing matching domains.
-        """
-        if self.must_train:
-            self.train()
-
-        return self.domain_engine.calc_intents(query)
-
-    def calc_domain(self, query: str) -> MatchData:
-        """
-        Calculate the best matching domain for a query.
-
-        Args:
-            query (str): The input query.
-
-        Returns:
-            MatchData: The best matching domain.
+        Each domain's :meth:`IntentContainer.calc_intent` returns its
+        top-1 match; the global argmax over those candidates wins.
+        ``domain`` restricts scoring to that domain.
         """
         if self.must_train:
             self.train()
-        return self.domain_engine.calc_intent(query)
+        if domain is not None:
+            container = self.domains.get(domain)
+            return (container.calc_intent(query) if container
+                    else MatchData(name=None, sent=query, matches=None, conf=0.0))
+        best = MatchData(name=None, sent=query, matches=None, conf=0.0)
+        for container in self.domains.values():
+            match = container.calc_intent(query)
+            if match.conf > best.conf:
+                best = match
+        return best
 
-    def calc_intent(self, query: str, domain: Optional[str] = None) -> MatchData:
-        """
-        Calculate the best matching intent for a query.
-
-        By default this follows the adapt-style parallel-argmax pattern:
-        every sub-domain container scores the query and the single highest
-        confidence intent wins globally. The legacy two-stage routing via
-        the top-level ``domain_engine`` is no longer used by default — that
-        engine remains trained for callers of :meth:`calc_domain`/
-        :meth:`calc_domains` but does not gate intent selection.
-
-        Args:
-            query (str): The input query.
-            domain (Optional[str]): If given, restrict matching to this domain.
-
-        Returns:
-            MatchData: The best matching intent across all domains (or
-            within the given domain).
-        """
+    def calc_intents(self, query: str,
+                      domain: Optional[str] = None) -> List[MatchData]:
+        """Per-domain best matches, sorted by confidence."""
         if self.must_train:
             self.train()
-        if domain:
-            if domain in self.domains:
-                return self.domains[domain].calc_intent(query)
-            return MatchData(name=None, sent=query, matches=None, conf=0.0)
-        matches = self.calc_intents(query)
-        if matches:
-            return matches[0]
-        return MatchData(name=None, sent=query, matches=None, conf=0.0)
+        if domain is not None:
+            container = self.domains.get(domain)
+            return container.calc_intents(query) if container else []
+        candidates = [c.calc_intent(query) for c in self.domains.values()]
+        return sorted(candidates, key=lambda m: m.conf, reverse=True)
 
-    def calc_intents(self, query: str, domain: Optional[str] = None,
-                     top_k_domains: Optional[int] = None) -> List[MatchData]:
-        """
-        Calculate matching intents for a query across domains.
-
-        Default behaviour is to score the query against every sub-domain
-        container in parallel and flatten the results (adapt-style
-        parallel argmax). ``top_k_domains`` is kept as an opt-in
-        optimisation hint: when set, the cheap domain-fingerprint engine
-        is consulted first and only the union of the top-K domains'
-        intents is scored.
-
-        Args:
-            query (str): The input query.
-            domain (Optional[str]): The specific domain to search in.
-                When given, ``top_k_domains`` is ignored.
-            top_k_domains (Optional[int]): Optional optimisation. When
-                set to a positive integer, restrict scoring to the top-K
-                domains as ranked by the top-level domain engine.
-                Defaults to None (score every domain).
-
-        Returns:
-            List[MatchData]: MatchData objects sorted by confidence (desc).
-        """
-        if self.must_train:
-            self.train()
-        if domain:
-            if domain in self.domains:
-                return self.domains[domain].calc_intents(query)
-            return []
-
-        if top_k_domains and top_k_domains > 0:
-            ranked = self.calc_domains(query)[:top_k_domains]
-            domain_names = [d.name for d in ranked if d.name in self.domains]
-        else:
-            domain_names = list(self.domains.keys())
-
-        matches: List[MatchData] = []
-        for name in domain_names:
-            matches += self.domains[name].calc_intents(query)
-        return sorted(matches, reverse=True, key=lambda k: k.conf)
-
-    def train(self):
-        for domain, samples in dict(self.training_data).items():  # copy for thread safety
-            LOG.debug(f"Training domain: {domain}")
-            self.domain_engine.add_intent(domain, samples)
-        self.domain_engine.train()
-        for domain in dict(self.domains): # copy for thread safety
-            LOG.debug(f"Training domain sub-intents: {domain}")
-            self.domains[domain].train()
+    def train(self) -> None:
+        for name, container in self.domains.items():
+            LOG.debug(f"Training domain: {name}")
+            container.train()
         self.must_train = False
+
+    # ── internal ───────────────────────────────────────────────────────
+
+    def _get_container(self, domain_name: str) -> IntentContainer:
+        if domain_name not in self.domains:
+            container = IntentContainer(
+                cache_dir=self.cache_dir,
+                disable_padaos=self.disable_padaos,
+            )
+            container.instantiate_from_disk()
+            self.domains[domain_name] = container
+        return self.domains[domain_name]

--- a/ovos_padatious/hierarchical_container.py
+++ b/ovos_padatious/hierarchical_container.py
@@ -1,0 +1,212 @@
+"""Hierarchical intent container — two-stage domain routing.
+
+Intents are grouped into domains. A top-level classifier first selects a
+single domain for the query; only that domain's :class:`IntentContainer`
+is then scored to resolve the intent. The top-level classifier is itself
+an :class:`IntentContainer` trained with each domain name as a label over
+the union of that domain's intent samples.
+"""
+from collections import defaultdict
+from typing import Dict, List, Optional
+
+from ovos_utils.log import LOG
+
+from ovos_padatious.intent_container import IntentContainer
+from ovos_padatious.match_data import MatchData
+
+
+class HierarchicalIntentContainer:
+    """Two-stage intent engine: domain classification followed by intent matching.
+
+    Intents are grouped into *domains*. At query time the engine first selects
+    the most likely domain, then runs that domain's intent container to find the
+    best intent within it.
+
+    The top-level domain classifier is trained automatically: every sample
+    passed to :meth:`register_domain_intent` is also fed to :attr:`domain_engine`
+    under its domain name, so the container works standalone with no manual
+    classifier setup.
+
+    Domains can also be selected explicitly, bypassing the top-level classifier.
+
+    Args:
+        cache_dir: Directory for caching neural network models, forwarded to
+            every :class:`IntentContainer` created internally. The top-level
+            classifier uses a ``_domains`` sub-directory.
+        disable_padaos: Disable the padaos regex layer on every child container.
+        domain_threshold: Minimum confidence the top-level classifier must
+            reach for a query to be routed at all. When the best domain scores
+            below this, :meth:`calc_intent` returns a no-match instead of
+            resolving an intent — this is the off-topic rejection gate.
+            ``0.0`` (default) disables the gate; every query is routed to its
+            best domain.
+    """
+
+    def __init__(self, cache_dir: Optional[str] = None,
+                 disable_padaos: bool = False,
+                 domain_threshold: float = 0.0) -> None:
+        self.cache_dir = cache_dir
+        self.disable_padaos = disable_padaos
+        self.domain_threshold = domain_threshold
+        #: Top-level classifier that maps free-text queries to a domain name.
+        self.domain_engine: IntentContainer = IntentContainer(
+            cache_dir=f"{cache_dir}/_domains" if cache_dir else None,
+            disable_padaos=disable_padaos,
+        )
+        #: Per-domain intent containers, keyed by domain name.
+        self.domains: Dict[str, IntentContainer] = {}
+        #: Raw training samples accumulated per domain.
+        self.training_data: Dict[str, List[str]] = defaultdict(list)
+        #: Domains whose classifier entry is stale and must be rebuilt.
+        self._dirty_domains: set = set()
+        self.must_train = True
+
+    def instantiate_from_disk(self) -> None:
+        """Compatibility hook.
+
+        Domain membership is not known until intents are registered, so
+        cached models are loaded lazily per domain by :meth:`_get_container`.
+        """
+
+    # ── internal ───────────────────────────────────────────────────────
+
+    def _get_container(self, domain_name: str) -> IntentContainer:
+        if domain_name not in self.domains:
+            container = IntentContainer(
+                cache_dir=self.cache_dir,
+                disable_padaos=self.disable_padaos,
+            )
+            container.instantiate_from_disk()
+            self.domains[domain_name] = container
+        return self.domains[domain_name]
+
+    def _sync_domain_classifier(self) -> None:
+        """Rebuild stale classifier entries.
+
+        Registration only marks a domain dirty; the top-level classifier is
+        rebuilt here, lazily, the first time a query needs it. This keeps bulk
+        registration linear instead of re-expanding the whole corpus per call.
+        """
+        for domain_name in self._dirty_domains:
+            if domain_name in self.domain_engine.intent_names:
+                self.domain_engine.remove_intent(domain_name)
+            samples = self.training_data.get(domain_name)
+            if samples:
+                self.domain_engine.add_intent(domain_name, samples)
+        self._dirty_domains.clear()
+
+    # ── domain management ──────────────────────────────────────────────
+
+    def remove_domain(self, domain_name: str) -> None:
+        """Remove a domain and all its intents, entities, and training data."""
+        self.training_data.pop(domain_name, None)
+        self.domains.pop(domain_name, None)
+        self._dirty_domains.discard(domain_name)
+        if domain_name in self.domain_engine.intent_names:
+            self.domain_engine.remove_intent(domain_name)
+        self.must_train = True
+
+    # ── intent management ──────────────────────────────────────────────
+
+    def add_domain_intent(self, domain_name: str, intent_name: str,
+                          intent_samples: List[str],
+                          blacklisted_words: Optional[List[str]] = None) -> None:
+        """Register an intent inside a domain.
+
+        Creates the domain's :class:`IntentContainer` on first use. The
+        top-level domain classifier is marked stale and rebuilt lazily on
+        the next query or :meth:`train` call.
+        """
+        self._get_container(domain_name).add_intent(
+            intent_name, intent_samples,
+            blacklisted_words=blacklisted_words,
+        )
+        self.training_data[domain_name] += intent_samples
+        self._dirty_domains.add(domain_name)
+        self.must_train = True
+
+    def remove_domain_intent(self, domain_name: str, intent_name: str) -> None:
+        """Remove a specific intent from a domain."""
+        if domain_name in self.domains:
+            self.domains[domain_name].remove_intent(intent_name)
+            self.must_train = True
+
+    # ── entity management ──────────────────────────────────────────────
+
+    def add_domain_entity(self, domain_name: str, entity_name: str,
+                          entity_samples: List[str]) -> None:
+        """Register an entity inside a domain."""
+        self._get_container(domain_name).add_entity(entity_name, entity_samples)
+        self.must_train = True
+
+    def remove_domain_entity(self, domain_name: str, entity_name: str) -> None:
+        """Remove a specific entity from a domain."""
+        if domain_name in self.domains:
+            self.domains[domain_name].remove_entity(entity_name)
+            self.must_train = True
+
+    # ── matching ───────────────────────────────────────────────────────
+
+    def calc_domain(self, query: str) -> MatchData:
+        """Classify *query* into the best-matching domain.
+
+        Returns a :class:`MatchData` whose ``name`` is the predicted domain.
+        """
+        if self.must_train:
+            self.train()
+        return self.domain_engine.calc_intent(query)
+
+    def calc_intent(self, query: str,
+                    domain: Optional[str] = None) -> MatchData:
+        """Return the best-matching intent for *query*, optionally within *domain*.
+
+        If *domain* is ``None``, the domain is inferred by :meth:`calc_domain`.
+        When the inferred domain scores below :attr:`domain_threshold`, or the
+        inferred/supplied domain has no registered intents, a no-match result
+        is returned. Passing *domain* explicitly bypasses the classifier and
+        the threshold gate.
+        """
+        if self.must_train:
+            self.train()
+        no_match = MatchData(name=None, sent=query, matches=None, conf=0.0)
+
+        resolved_domain: Optional[str] = domain
+        if resolved_domain is None:
+            dom_result = self.domain_engine.calc_intent(query)
+            if dom_result.conf < self.domain_threshold:
+                return no_match
+            resolved_domain = dom_result.name
+
+        if resolved_domain in self.domains:
+            return self.domains[resolved_domain].calc_intent(query)
+        return no_match
+
+    def calc_intents(self, query: str,
+                     domain: Optional[str] = None) -> List[MatchData]:
+        """Return matches from the routed (or supplied) domain only.
+
+        Two-stage routing picks a single domain; the returned list contains
+        that domain's candidate matches. An empty list signals no match.
+        """
+        if self.must_train:
+            self.train()
+        resolved_domain: Optional[str] = domain
+        if resolved_domain is None:
+            dom_result = self.domain_engine.calc_intent(query)
+            if dom_result.conf < self.domain_threshold:
+                return []
+            resolved_domain = dom_result.name
+
+        if resolved_domain in self.domains:
+            return self.domains[resolved_domain].calc_intents(query)
+        return []
+
+    def train(self) -> None:
+        """Train the top-level classifier and every domain container."""
+        self._sync_domain_classifier()
+        LOG.debug("Training hierarchical domain classifier")
+        self.domain_engine.train()
+        for name, container in self.domains.items():
+            LOG.debug(f"Training domain: {name}")
+            container.train()
+        self.must_train = False

--- a/ovos_padatious/opm.py
+++ b/ovos_padatious/opm.py
@@ -1023,6 +1023,25 @@ class HierarchicalPadatiousPipeline(PadatiousPipeline):
             container.domain_threshold = self.domain_threshold
 
 
+def _faithful_case(value: str, utt: str) -> str:
+    """Return ``value`` in the case it appears with in ``utt``.
+
+    Slot values come back from the lowercase-normalized match; when the same
+    token sequence occurs verbatim (case-insensitively) as a whole-word run in
+    the original utterance, report that faithful-case span instead. Falls back
+    to the normalized value when no such span is found.
+    """
+    needle = str(value).lower().split()
+    if not needle:
+        return value
+    tokens = str(utt).split()
+    lowered = [t.lower() for t in tokens]
+    for i in range(len(lowered) - len(needle) + 1):
+        if lowered[i:i + len(needle)] == needle:
+            return " ".join(tokens[i:i + len(needle)])
+    return value
+
+
 @lru_cache(maxsize=3)  # repeat calls under different conf levels wont re-run code
 def _calc_padatious_intent(utt: str,
                            intent_container: Union[IntentContainer, DomainIntentContainer],
@@ -1053,6 +1072,13 @@ def _calc_padatious_intent(utt: str,
             match for match in matches if match.conf == best_match.conf)
         intent = min(best_matches, key=lambda x: sum(map(len, x.matches.values())))
         intent.sent = utt
+        # OVOS-INTENT-1 §2: matching runs on the lowercase-normalized input, but
+        # an exact match binds each slot to a verbatim span of the utterance, so
+        # its value can be reported in the utterance's faithful case. A fuzzy
+        # match has no such guarantee and keeps the normalized (lowercase) value.
+        if intent.conf >= 1.0:
+            intent.matches = {slot: _faithful_case(value, utt)
+                              for slot, value in (intent.matches or {}).items()}
         return intent
     except Exception as e:
         LOG.error(e)

--- a/ovos_padatious/opm.py
+++ b/ovos_padatious/opm.py
@@ -30,6 +30,7 @@ from ovos_bus_client.message import Message
 from ovos_bus_client.session import SessionManager, Session
 from ovos_padatious import IntentContainer
 from ovos_padatious.domain_container import DomainIntentContainer
+from ovos_padatious.hierarchical_container import HierarchicalIntentContainer
 from ovos_padatious.match_data import MatchData as PadatiousIntent
 from ovos_plugin_manager.templates.pipeline import ConfidenceMatcherPipeline, IntentHandlerMatch
 from ovos_spec_tools import closest_lang, expand as expand_template, standardize_lang
@@ -46,7 +47,11 @@ import faulthandler
 PadatiousIntentContainer = IntentContainer  # backwards compat
 
 # for easy typing
-PadatiousEngine = Union[Type[IntentContainer], Type[DomainIntentContainer]]
+PadatiousEngine = Union[Type[IntentContainer], Type[DomainIntentContainer],
+                        Type[HierarchicalIntentContainer]]
+
+# containers that group intents per domain (skill_id) under a shared API
+_DOMAIN_ENGINES = (DomainIntentContainer, HierarchicalIntentContainer)
 
 
 # OVOS-INTENT-1: a template slot is written ``{entity_name}`` in a sample; the
@@ -217,6 +222,8 @@ class PadatiousPipeline(ConfidenceMatcherPipeline):
             # allow user to switch back and forth without retraining
             # cache is cheap, training isn't
             intent_cache += "_domain"
+        elif self.engine_class == HierarchicalIntentContainer:
+            intent_cache += "_hierarchical"
         if use_stemmer:
             intent_cache += "_stemmer"
         if self.remove_punct:
@@ -416,7 +423,7 @@ class PadatiousPipeline(ConfidenceMatcherPipeline):
                 for skill_id, intents in self._skill2intent.items():
                     if intent_name in intents:
                         try:
-                            if isinstance(self.containers[lang], DomainIntentContainer):
+                            if isinstance(self.containers[lang], _DOMAIN_ENGINES):
                                 self.containers[lang].remove_domain_intent(skill_id, intent_name)
                             else:
                                 self.containers[lang].remove_intent(intent_name)
@@ -536,7 +543,7 @@ class PadatiousPipeline(ConfidenceMatcherPipeline):
                 self.registered_intents.append(message.data['name'])
             LOG.debug('Registering Padatious intent: ' + message.data['name'])
             lang, skill_id, name, samples, blacklisted_words = self._unpack_object(message)
-            if self.engine_class == DomainIntentContainer:
+            if isinstance(self.containers[lang], _DOMAIN_ENGINES):
                 self.containers[lang].add_domain_intent(skill_id, name, samples,
                                                         blacklisted_words=blacklisted_words)
             else:
@@ -558,7 +565,7 @@ class PadatiousPipeline(ConfidenceMatcherPipeline):
             self.registered_entities.append(message.data)
             lang, skill_id, name, samples, _ = self._unpack_object(message)
             LOG.debug('Registering Padatious entity: ' + message.data['name'])
-            if self.engine_class == DomainIntentContainer:
+            if isinstance(self.containers[lang], _DOMAIN_ENGINES):
                 self.containers[lang].add_domain_entity(skill_id, name, samples)
             else:
                 self.containers[lang].add_entity(name, samples)
@@ -983,6 +990,34 @@ class DomainPadatiousPipeline(PadatiousPipeline):
             config = Configuration().get('intents', {}).get(
                 "ovos-padatious-domain-pipeline-plugin") or {}
         super().__init__(bus=bus, config=config, engine_class=DomainIntentContainer)
+
+
+class HierarchicalPadatiousPipeline(PadatiousPipeline):
+    """Padatious pipeline backed by :class:`HierarchicalIntentContainer`.
+
+    Each registered skill becomes its own domain. Matching is two-stage: a
+    top-level classifier first selects a single domain, then only that
+    domain's intents are scored. Utterances whose best domain scores below
+    ``domain_threshold`` are rejected before any sub-container runs.
+
+    Configuration is read from
+    ``intents.ovos-padatious-hierarchical-pipeline-plugin`` (or
+    ``padatious_hierarchical``). It accepts every key the flat pipeline does,
+    plus ``domain_threshold`` — the minimum top-level classifier confidence
+    required to route a query (``0.0`` disables the gate).
+    """
+
+    def __init__(self, bus: Optional[Union[MessageBusClient, FakeBus]] = None,
+                 config: Optional[Dict] = None):
+        if config is None:
+            intent_config = Configuration().get('intents', {})
+            config = (intent_config.get("ovos-padatious-hierarchical-pipeline-plugin")
+                      or intent_config.get("padatious_hierarchical") or {})
+        self.domain_threshold = (config or {}).get("domain_threshold", 0.0)
+        super().__init__(bus=bus, config=config,
+                         engine_class=HierarchicalIntentContainer)
+        for container in self.containers.values():
+            container.domain_threshold = self.domain_threshold
 
 
 @lru_cache(maxsize=3)  # repeat calls under different conf levels wont re-run code

--- a/ovos_padatious/opm.py
+++ b/ovos_padatious/opm.py
@@ -202,7 +202,10 @@ class PadatiousPipeline(ConfidenceMatcherPipeline):
         self.conf_med = self.config.get("conf_med") or 0.8
         self.conf_low = self.config.get("conf_low") or 0.5
 
-        engine_class = engine_class or DomainIntentContainer if self.config.get("domain_engine") else IntentContainer
+        if engine_class is None:
+            engine_class = (DomainIntentContainer
+                            if self.config.get("domain_engine")
+                            else IntentContainer)
         LOG.info(f"Padatious class: {engine_class.__name__}")
 
         self.remove_punct = self.config.get("cast_to_ascii", False)

--- a/ovos_padatious/opm.py
+++ b/ovos_padatious/opm.py
@@ -53,6 +53,11 @@ PadatiousEngine = Union[Type[IntentContainer], Type[DomainIntentContainer],
 # containers that group intents per domain (skill_id) under a shared API
 _DOMAIN_ENGINES = (DomainIntentContainer, HierarchicalIntentContainer)
 
+# trailing punctuation safe to strip from samples — excludes the characters
+# padatious template syntax relies on ({entity}, [optional], (a|b))
+_TEMPLATE_SYNTAX = set("{}[]()|<>")
+_STRIPPABLE_PUNCT = "".join(c for c in string.punctuation if c not in _TEMPLATE_SYNTAX)
+
 
 # OVOS-INTENT-1: a template slot is written ``{entity_name}`` in a sample; the
 # padaos parser recognises the same lowercase/underscore/colon name form.
@@ -87,11 +92,9 @@ def normalize_utterances(utterances: List[str], lang: str, cast_to_ascii: bool =
     # Replace accented characters and punctuation if needed
     if cast_to_ascii:
         utterances = [remove_accents_and_punct(u) for u in utterances]
-    # strip trailing punctuation, that just causes duplicate training data —
-    # but preserve the slot/vocabulary metacharacters {} <> so a template
-    # ending in a slot ({name}) keeps its closing brace (OVOS-INTENT-1 §3)
-    _trailing_punct = ''.join(c for c in string.punctuation if c not in '{}<>')
-    utterances = [u.rstrip(_trailing_punct) for u in utterances]
+    # strip punctuation marks, that just causes duplicate training data;
+    # template-syntax characters ({entity}, [optional], (a|b)) are preserved
+    utterances = [u.rstrip(_STRIPPABLE_PUNCT) for u in utterances]
     # Stem words if stemmer is provided
     if stemmer is not None:
         utterances = stemmer.stem_sentences(utterances)

--- a/ovos_padatious/opm.py
+++ b/ovos_padatious/opm.py
@@ -202,7 +202,17 @@ class PadatiousPipeline(ConfidenceMatcherPipeline):
         self.conf_med = self.config.get("conf_med") or 0.8
         self.conf_low = self.config.get("conf_low") or 0.5
 
-        engine_class = engine_class or DomainIntentContainer if self.config.get("domain_engine") else IntentContainer
+        if engine_class is None:
+            if self.config.get("domain_engine"):
+                log_deprecation(
+                    "'domain_engine: true' is deprecated; select the "
+                    "'ovos-padatious-domain-pipeline-plugin' OPM entry "
+                    "point instead",
+                    "2.0.0",
+                )
+                engine_class = DomainIntentContainer
+            else:
+                engine_class = IntentContainer
         LOG.info(f"Padatious class: {engine_class.__name__}")
 
         self.remove_punct = self.config.get("cast_to_ascii", False)
@@ -980,6 +990,41 @@ def _canonicalize_blacklist(blacklisted_intents: frozenset) -> frozenset:
                 f"be removed. Update mycroft.conf / session config to use the "
                 f"canonical id '{c}' instead.")
     return frozenset(canonical)
+
+
+class DomainPadatiousPipeline(PadatiousPipeline):
+    """Padatious pipeline backed by :class:`DomainIntentContainer`.
+
+    This variant is exposed as its own OPM entry point
+    (``ovos-padatious-domain-pipeline-plugin``) so the domain-aware
+    engine can be selected at the pipeline level rather than through
+    the legacy ``domain_engine: true`` config flag on the flat
+    pipeline.
+
+    Configuration is read from ``intents.ovos-padatious-domain-pipeline-plugin``
+    (falling back to ``intents.padatious_domain``). The ``engine_class``
+    is forced to :class:`DomainIntentContainer` regardless of any
+    ``domain_engine`` flag.
+
+    Intent registration is routed via ``add_domain_intent(skill_id,
+    name, ...)`` — the skill_id is treated as the domain. The intent
+    label's ``skill_id:intent_name`` prefix is used; if no ``:`` is
+    present the full intent name is used as both domain and intent
+    name (matching the parent pipeline's prefix-splitting convention).
+    """
+
+    def __init__(self, bus: Optional[Union[MessageBusClient, FakeBus]] = None,
+                 config: Optional[Dict] = None,
+                 engine_class: Optional[PadatiousEngine] = None):
+        if config is None:
+            intent_config = Configuration().get('intents', {})
+            config = (intent_config.get("ovos-padatious-domain-pipeline-plugin")
+                      or intent_config.get("padatious_domain")
+                      or dict())
+        # Force the domain engine regardless of the deprecated flag.
+        config = dict(config)
+        config["domain_engine"] = True
+        super().__init__(bus=bus, config=config, engine_class=DomainIntentContainer)
 
 
 @lru_cache(maxsize=3)  # repeat calls under different conf levels wont re-run code

--- a/ovos_padatious/opm.py
+++ b/ovos_padatious/opm.py
@@ -202,17 +202,7 @@ class PadatiousPipeline(ConfidenceMatcherPipeline):
         self.conf_med = self.config.get("conf_med") or 0.8
         self.conf_low = self.config.get("conf_low") or 0.5
 
-        if engine_class is None:
-            if self.config.get("domain_engine"):
-                log_deprecation(
-                    "'domain_engine: true' is deprecated; select the "
-                    "'ovos-padatious-domain-pipeline-plugin' OPM entry "
-                    "point instead",
-                    "2.0.0",
-                )
-                engine_class = DomainIntentContainer
-            else:
-                engine_class = IntentContainer
+        engine_class = engine_class or DomainIntentContainer if self.config.get("domain_engine") else IntentContainer
         LOG.info(f"Padatious class: {engine_class.__name__}")
 
         self.remove_punct = self.config.get("cast_to_ascii", False)
@@ -399,10 +389,6 @@ class PadatiousPipeline(ConfidenceMatcherPipeline):
             self.bus.emit(Message('mycroft.skills.trained'))
             self.finished_training_event.set()
 
-        # Training changes the model; stale LRU cache entries must be evicted
-        # so that the next call to calc_intent reflects the updated state.
-        _calc_padatious_intent.cache_clear()
-
         if not self.first_train.is_set():
             self.first_train.set()
 
@@ -441,13 +427,6 @@ class PadatiousPipeline(ConfidenceMatcherPipeline):
             message (Message): message triggering action
         """
         self.__detach_intent(message.data.get('intent_name'))
-        # Intent roster changed; evict stale cache so next match reflects removal.
-        _calc_padatious_intent.cache_clear()
-        # In instant_train mode, retrain immediately so the model also
-        # forgets the intent — otherwise the cleared cache repopulates from
-        # the still-trained model on the next match.
-        if self.config.get("instant_train", False):
-            self.train(message)
 
     def handle_detach_skill(self, message):
         """Messagebus handler for detaching all intents for skill.
@@ -461,12 +440,6 @@ class PadatiousPipeline(ConfidenceMatcherPipeline):
             skill_id = "anonymous_skill"
         for i in self._skill2intent[skill_id]:
             self.__detach_intent(i)
-        # Intent roster changed; evict stale cache so next match reflects removal.
-        _calc_padatious_intent.cache_clear()
-        # See handle_detach_intent — retrain in instant_train mode so the
-        # underlying model state matches the registered_intents list.
-        if self.config.get("instant_train", False):
-            self.train(message)
 
     def _unpack_object(self, message):
         """convert message to training data"""
@@ -995,35 +968,17 @@ def _canonicalize_blacklist(blacklisted_intents: frozenset) -> frozenset:
 class DomainPadatiousPipeline(PadatiousPipeline):
     """Padatious pipeline backed by :class:`DomainIntentContainer`.
 
-    This variant is exposed as its own OPM entry point
-    (``ovos-padatious-domain-pipeline-plugin``) so the domain-aware
-    engine can be selected at the pipeline level rather than through
-    the legacy ``domain_engine: true`` config flag on the flat
-    pipeline.
-
-    Configuration is read from ``intents.ovos-padatious-domain-pipeline-plugin``
-    (falling back to ``intents.padatious_domain``). The ``engine_class``
-    is forced to :class:`DomainIntentContainer` regardless of any
-    ``domain_engine`` flag.
-
-    Intent registration is routed via ``add_domain_intent(skill_id,
-    name, ...)`` — the skill_id is treated as the domain. The intent
-    label's ``skill_id:intent_name`` prefix is used; if no ``:`` is
-    present the full intent name is used as both domain and intent
-    name (matching the parent pipeline's prefix-splitting convention).
+    Each registered skill becomes its own domain; matching scans every
+    domain in parallel and the highest-confidence intent wins.
+    Configuration is read from
+    ``intents.ovos-padatious-domain-pipeline-plugin``.
     """
 
     def __init__(self, bus: Optional[Union[MessageBusClient, FakeBus]] = None,
-                 config: Optional[Dict] = None,
-                 engine_class: Optional[PadatiousEngine] = None):
+                 config: Optional[Dict] = None):
         if config is None:
-            intent_config = Configuration().get('intents', {})
-            config = (intent_config.get("ovos-padatious-domain-pipeline-plugin")
-                      or intent_config.get("padatious_domain")
-                      or dict())
-        # Force the domain engine regardless of the deprecated flag.
-        config = dict(config)
-        config["domain_engine"] = True
+            config = Configuration().get('intents', {}).get(
+                "ovos-padatious-domain-pipeline-plugin") or {}
         super().__init__(bus=bus, config=config, engine_class=DomainIntentContainer)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ Homepage = "https://github.com/OpenVoiceOS/ovos-padatious-pipeline-plugin"
 
 [project.entry-points."opm.pipeline"]
 "ovos-padatious-pipeline-plugin" = "ovos_padatious.opm:PadatiousPipeline"
+"ovos-padatious-domain-pipeline-plugin" = "ovos_padatious.opm:DomainPadatiousPipeline"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,12 @@ test = [
     "ovos-bus-client>=2.5.1a1,<3.0.0",
     "ovos-spec-tools>=1.5.0a1",
 ]
+benchmark = [
+    "padaos",
+    "nebulento",
+    "datasets",
+    "fann2==1.0.7",
+]
 
 [project.urls]
 Homepage = "https://github.com/OpenVoiceOS/ovos-padatious-pipeline-plugin"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ Homepage = "https://github.com/OpenVoiceOS/ovos-padatious-pipeline-plugin"
 [project.entry-points."opm.pipeline"]
 "ovos-padatious-pipeline-plugin" = "ovos_padatious.opm:PadatiousPipeline"
 "ovos-padatious-domain-pipeline-plugin" = "ovos_padatious.opm:DomainPadatiousPipeline"
+"ovos-padatious-hierarchical-pipeline-plugin" = "ovos_padatious.opm:HierarchicalPadatiousPipeline"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1,93 +1,73 @@
 import unittest
 from unittest.mock import MagicMock
 
-from ovos_padatious.domain_container import DomainIntentContainer  # Replace 'your_module' with the actual module name
-
+from ovos_padatious.domain_container import DomainIntentContainer
 from ovos_padatious.match_data import MatchData
 
 
-class TestDomainIntentEngine(unittest.TestCase):
+class TestDomainIntentContainer(unittest.TestCase):
     def setUp(self):
         self.engine = DomainIntentContainer()
 
-    def test_register_domain_intent(self):
+    def test_add_domain_intent_creates_container(self):
         self.engine.add_domain_intent("domain1", "intent1", ["sample1", "sample2"])
-        self.assertIn("domain1", self.engine.training_data)
+        self.assertIn("domain1", self.engine.domains)
         self.assertIn("intent1", self.engine.domains["domain1"].intent_names)
 
     def test_remove_domain(self):
-        self.engine.add_domain_intent("domain1", "intent1", ["sample1", "sample2"])
+        self.engine.add_domain_intent("domain1", "intent1", ["sample1"])
         self.engine.remove_domain("domain1")
-        self.assertNotIn("domain1", self.engine.training_data)
         self.assertNotIn("domain1", self.engine.domains)
 
     def test_remove_domain_intent(self):
-        self.engine.add_domain_intent("domain1", "intent1", ["sample1", "sample2"])
+        self.engine.add_domain_intent("domain1", "intent1", ["sample1"])
         self.engine.remove_domain_intent("domain1", "intent1")
         self.assertNotIn("intent1", self.engine.domains["domain1"].intent_names)
 
-    def test_calc_domains(self):
+    def test_calc_intent_picks_global_argmax(self):
         self.engine.train = MagicMock()
-        self.engine.domain_engine.calc_intents = MagicMock(
-            return_value=[MatchData(name="domain1", sent="query", matches=None, conf=0.9)])
-        result = self.engine.calc_domains("query")
-        self.engine.train.assert_called_once()
-        self.assertEqual(result[0].name, "domain1")
+        dom_a, dom_b = MagicMock(), MagicMock()
+        dom_a.calc_intent.return_value = MatchData(name="a", sent="q", matches=None, conf=0.6)
+        dom_b.calc_intent.return_value = MatchData(name="b", sent="q", matches=None, conf=0.9)
+        self.engine.domains["A"] = dom_a
+        self.engine.domains["B"] = dom_b
+        result = self.engine.calc_intent("q")
+        self.assertEqual(result.name, "b")
+        self.assertEqual(result.conf, 0.9)
 
-    def test_calc_domain(self):
+    def test_calc_intent_restricted_to_domain(self):
         self.engine.train = MagicMock()
-        self.engine.domain_engine.calc_intent = MagicMock(
-            return_value=MatchData(name="domain1", sent="query", matches=None, conf=0.9))
-        result = self.engine.calc_domain("query")
-        self.engine.train.assert_called_once()
-        self.assertEqual(result.name, "domain1")
+        dom_a, dom_b = MagicMock(), MagicMock()
+        dom_a.calc_intent.return_value = MatchData(name="a", sent="q", matches=None, conf=0.6)
+        dom_b.calc_intent.return_value = MatchData(name="b", sent="q", matches=None, conf=0.9)
+        self.engine.domains["A"] = dom_a
+        self.engine.domains["B"] = dom_b
+        result = self.engine.calc_intent("q", domain="A")
+        self.assertEqual(result.name, "a")
 
-    def test_calc_intent(self):
-        # New parallel-argmax behaviour: every domain is scored and the
-        # global best wins, no top-level routing required.
+    def test_calc_intents_returns_per_domain_best(self):
         self.engine.train = MagicMock()
-        mock_domain_container = MagicMock()
-        mock_domain_container.calc_intents.return_value = [
-            MatchData(name="intent1", sent="query", matches=None, conf=0.9),
-        ]
-        self.engine.domains["domain1"] = mock_domain_container
-        result = self.engine.calc_intent("query")
-        self.assertEqual(result.name, "intent1")
+        dom_a, dom_b = MagicMock(), MagicMock()
+        dom_a.calc_intent.return_value = MatchData(name="a", sent="q", matches=None, conf=0.6)
+        dom_b.calc_intent.return_value = MatchData(name="b", sent="q", matches=None, conf=0.9)
+        self.engine.domains["A"] = dom_a
+        self.engine.domains["B"] = dom_b
+        result = self.engine.calc_intents("q")
+        self.assertEqual([m.name for m in result], ["b", "a"])
 
-    def test_calc_intents(self):
-        self.engine.train = MagicMock()
-        mock_domain_container = MagicMock()
-        mock_domain_container.calc_intents.return_value = [
-            MatchData(name="intent1", sent="query", matches=None, conf=0.9),
-            MatchData(name="intent2", sent="query", matches=None, conf=0.8),
-        ]
-        self.engine.domains["domain1"] = mock_domain_container
-
-        self.engine.domain_engine.calc_intents = MagicMock(
-            return_value=[MatchData(name="domain1", sent="query", matches=None, conf=0.9)])
-        result = self.engine.calc_intents("query")
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0].name, "intent1")
-
-    def test_train(self):
-        self.engine.training_data["domain1"] = ["sample1", "sample2"]
-        self.engine.domain_engine.add_intent = MagicMock()
-        self.engine.domain_engine.train = MagicMock()
-
-        mock_domain_container = MagicMock()
-        self.engine.domains["domain1"] = mock_domain_container
-
+    def test_train_calls_each_container(self):
+        dom_a, dom_b = MagicMock(), MagicMock()
+        self.engine.domains["A"] = dom_a
+        self.engine.domains["B"] = dom_b
         self.engine.train()
-        self.engine.domain_engine.add_intent.assert_called_with("domain1", ["sample1", "sample2"])
-        self.engine.domain_engine.train.assert_called_once()
-        mock_domain_container.train.assert_called_once()
+        dom_a.train.assert_called_once()
+        dom_b.train.assert_called_once()
         self.assertFalse(self.engine.must_train)
 
 
-class TestDomainIntentEngineWithLiveData(unittest.TestCase):
+class TestDomainIntentContainerWithLiveData(unittest.TestCase):
     def setUp(self):
         self.engine = DomainIntentContainer()
-        # Sample training data
         self.training_data = {
             "IOT": {
                 "turn_on_device": ["Turn on the lights", "Switch on the fan", "Activate the air conditioner"],
@@ -110,74 +90,32 @@ class TestDomainIntentEngineWithLiveData(unittest.TestCase):
                 "stop_music": ["Stop the music", "Pause playback", "Halt the song"],
             },
         }
-        # Register domains and intents
         for domain, intents in self.training_data.items():
             for intent, samples in intents.items():
                 self.engine.add_domain_intent(domain, intent, samples)
         self.engine.train()
 
-    def test_live_data_intent_matching(self):
-        # Test IOT domain
-        query = "Switch on the fan"
-        result = self.engine.calc_intent(query, domain="IOT")
-        self.assertEqual(result.name, "turn_on_device")
-        self.assertGreater(result.conf, 0.8)
+    def test_restricted_domain_match(self):
+        for query, domain, expected in [
+            ("Switch on the fan", "IOT", "turn_on_device"),
+            ("Hi there", "greetings", "say_hello"),
+            ("What is the capital of France?", "General Knowledge", "ask_fact"),
+            ("Why is the sky blue?", "Question", "ask_question"),
+            ("Play a song", "Media Playback", "play_music"),
+        ]:
+            result = self.engine.calc_intent(query, domain=domain)
+            self.assertEqual(result.name, expected)
+            self.assertGreater(result.conf, 0.8)
 
-        # Test greetings domain
-        query = "Hi there"
-        result = self.engine.calc_intent(query, domain="greetings")
-        self.assertEqual(result.name, "say_hello")
-        self.assertGreater(result.conf, 0.8)
-
-        # Test General Knowledge domain
-        query = "What is the capital of France?"
-        result = self.engine.calc_intent(query, domain="General Knowledge")
-        self.assertEqual(result.name, "ask_fact")
-        self.assertGreater(result.conf, 0.8)
-
-        # Test Question domain
-        query = "Why is the sky blue?"
-        result = self.engine.calc_intent(query, domain="Question")
-        self.assertEqual(result.name, "ask_question")
-        self.assertGreater(result.conf, 0.8)
-
-        # Test Media Playback domain
-        query = "Play a song"
-        result = self.engine.calc_intent(query, domain="Media Playback")
-        self.assertEqual(result.name, "play_music")
-        self.assertGreater(result.conf, 0.8)
-
-    def test_live_data_cross_domain_matching(self):
-        # Test cross-domain intent matching
-        query = "Tell me a fact about space"
-        result = self.engine.calc_domain(query)
-        self.assertEqual(result.name, "General Knowledge")
-        self.assertGreater(result.conf, 0.8)
-
-        # Validate intent from the matched domain
-        result = self.engine.calc_intent(query, domain=result.name)
-        self.assertEqual(result.name, "ask_fact")
-        self.assertGreater(result.conf, 0.8)
-
-    def test_calc_intent_without_domain(self):
-        # Test intent calculation without specifying a domain
-        query = "Turn on the lights"
-        result = self.engine.calc_intent(query)
-        self.assertIsNotNone(result.name, "Intent name should not be None")
-        self.assertEqual(result.name, "turn_on_device")
-        self.assertGreater(result.conf, 0.8)
-
-        query = "Goodbye"
-        result = self.engine.calc_intent(query)
-        self.assertIsNotNone(result.name, "Intent name should not be None")
-        self.assertEqual(result.name, "say_goodbye")
-        self.assertGreater(result.conf, 0.8)
-
-        query = "What is quantum mechanics?"
-        result = self.engine.calc_intent(query)
-        self.assertIsNotNone(result.name, "Intent name should not be None")
-        self.assertEqual(result.name, "ask_question")
-        self.assertGreater(result.conf, 0.8)
+    def test_unrestricted_global_argmax(self):
+        for query, expected in [
+            ("Turn on the lights", "turn_on_device"),
+            ("Goodbye", "say_goodbye"),
+            ("What is quantum mechanics?", "ask_question"),
+        ]:
+            result = self.engine.calc_intent(query)
+            self.assertEqual(result.name, expected)
+            self.assertGreater(result.conf, 0.8)
 
 
 if __name__ == "__main__":

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -43,13 +43,14 @@ class TestDomainIntentEngine(unittest.TestCase):
         self.assertEqual(result.name, "domain1")
 
     def test_calc_intent(self):
+        # New parallel-argmax behaviour: every domain is scored and the
+        # global best wins, no top-level routing required.
         self.engine.train = MagicMock()
         mock_domain_container = MagicMock()
-        mock_domain_container.calc_intent.return_value = MatchData(name="intent1", sent="query", matches=None, conf=0.9)
+        mock_domain_container.calc_intents.return_value = [
+            MatchData(name="intent1", sent="query", matches=None, conf=0.9),
+        ]
         self.engine.domains["domain1"] = mock_domain_container
-
-        self.engine.domain_engine.calc_intent = MagicMock(
-            return_value=MatchData(name="domain1", sent="query", matches=None, conf=0.9))
         result = self.engine.calc_intent("query")
         self.assertEqual(result.name, "intent1")
 

--- a/tests/test_domain_benefit.py
+++ b/tests/test_domain_benefit.py
@@ -1,0 +1,65 @@
+"""Toy benchmark: an utterance the flat container misclassifies but
+the DomainIntentContainer gets right.
+
+Two skills share a "set X to Y" template surface. With every intent in
+a single flat container, padatious sees ``set thermostat to N`` and
+``set volume to N`` as near-duplicates and the global argmax can fall
+on the wrong intent. Partitioning by skill domain narrows each
+container's decision space; the per-domain top-1 plus global argmax
+picks the right side.
+"""
+import unittest
+
+from ovos_padatious.domain_container import DomainIntentContainer
+from ovos_padatious.intent_container import IntentContainer
+
+
+HOME = {
+    "turn_on_lights":  ["turn on the lights", "lights on", "switch on the light"],
+    "turn_off_lights": ["turn off the lights", "lights off", "switch off the light"],
+    "set_thermostat":  ["set thermostat to 20 degrees",
+                        "make it 22 degrees",
+                        "set the temperature to 18"],
+}
+
+MEDIA = {
+    "play_song":  ["play africa", "put on bohemian rhapsody", "play hey jude"],
+    "pause_song": ["pause", "pause the music", "stop playback"],
+    "set_volume": ["set volume to 5",
+                   "make it 7 loud",
+                   "set the volume to 3"],
+}
+
+# Utterance the flat engine often miscategorises because "set X to Y"
+# matches set_thermostat at least as well as set_volume.
+AMBIGUOUS = "set volume to 8"
+EXPECTED_INTENT = "set_volume"
+
+
+class TestDomainBeatsFlat(unittest.TestCase):
+    def test_domain_picks_set_volume_when_flat_misroutes(self):
+        flat = IntentContainer()
+        for name, samples in {**HOME, **MEDIA}.items():
+            flat.add_intent(name, samples)
+        flat.train()
+        flat_match = flat.calc_intent(AMBIGUOUS)
+
+        domain = DomainIntentContainer()
+        for name, samples in HOME.items():
+            domain.add_domain_intent("home", name, samples)
+        for name, samples in MEDIA.items():
+            domain.add_domain_intent("media", name, samples)
+        domain.train()
+        domain_match = domain.calc_intent(AMBIGUOUS)
+
+        # The whole point of the test: domain routing finds the right
+        # intent here. We don't strictly require the flat container to
+        # fail (padatious is sometimes good enough), but when the
+        # difference shows up, the domain side must win.
+        self.assertEqual(domain_match.name, EXPECTED_INTENT)
+        if flat_match.name != EXPECTED_INTENT:
+            self.assertNotEqual(flat_match.name, domain_match.name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_domain_pipeline.py
+++ b/tests/test_domain_pipeline.py
@@ -1,8 +1,7 @@
-"""Tests for the new DomainPadatiousPipeline OPM entry point.
+"""Tests for the DomainPadatiousPipeline OPM entry point.
 
 Exercises:
-  - the pipeline auto-selects DomainIntentContainer (no `domain_engine`
-    flag needed).
+  - the pipeline constructs a DomainIntentContainer.
   - skill_id is used as the domain when registering intents.
   - detach via remove_domain_intent / remove_domain (skill detach).
   - end-to-end intent matching via add_domain_intent routing.

--- a/tests/test_domain_pipeline.py
+++ b/tests/test_domain_pipeline.py
@@ -1,0 +1,112 @@
+"""Tests for the new DomainPadatiousPipeline OPM entry point.
+
+Exercises:
+  - the pipeline auto-selects DomainIntentContainer (no `domain_engine`
+    flag needed).
+  - skill_id is used as the domain when registering intents.
+  - detach via remove_domain_intent / remove_domain (skill detach).
+  - end-to-end intent matching via add_domain_intent routing.
+"""
+import os
+import tempfile
+import unittest
+
+from ovos_bus_client.message import Message
+from ovos_utils.messagebus import FakeBus
+
+from ovos_padatious.domain_container import DomainIntentContainer
+from ovos_padatious.opm import DomainPadatiousPipeline
+
+
+def _make_pipeline(cache_dir):
+    return DomainPadatiousPipeline(
+        FakeBus(),
+        config={
+            "intent_cache": cache_dir,
+            "train_delay": 1,
+            "single_thread": True,
+            "instant_train": True,
+            "conf_low": 0.5,
+        },
+    )
+
+
+class TestDomainPadatiousPipeline(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.cache_dir = self._tmp.name
+        self.pipeline = _make_pipeline(self.cache_dir)
+
+    def tearDown(self):
+        self.pipeline.shutdown()
+        self._tmp.cleanup()
+
+    def test_engine_class_is_domain_container(self):
+        self.assertIs(self.pipeline.engine_class, DomainIntentContainer)
+        for c in self.pipeline.containers.values():
+            self.assertIsInstance(c, DomainIntentContainer)
+
+    def test_skill_id_is_domain_on_register(self):
+        skill_id = "weather.skill"
+        self.pipeline.register_intent(Message("padatious:register_intent", {
+            "name": f"{skill_id}:current",
+            "samples": ["what is the weather", "tell me the weather"],
+            "lang": "en-US",
+            "skill_id": skill_id,
+        }))
+        container = next(iter(self.pipeline.containers.values()))
+        # The skill_id must have become a domain in the container.
+        self.assertIn(skill_id, container.domains)
+        self.assertIn(f"{skill_id}:current",
+                      container.domains[skill_id].intent_names)
+
+    def test_intent_matches_via_domain_routing(self):
+        skill_id = "hello.skill"
+        self.pipeline.register_intent(Message("padatious:register_intent", {
+            "name": f"{skill_id}:hello",
+            "samples": ["hello", "hi", "hey there", "good morning"],
+            "lang": "en-US",
+            "skill_id": skill_id,
+        }))
+        self.pipeline.train()
+        intent = self.pipeline.calc_intent("hello", "en-US")
+        self.assertIsNotNone(intent)
+        self.assertEqual(intent.name, f"{skill_id}:hello")
+
+    def test_detach_intent_uses_remove_domain_intent(self):
+        skill_id = "iot.skill"
+        intent_name = f"{skill_id}:lights_on"
+        self.pipeline.register_intent(Message("padatious:register_intent", {
+            "name": intent_name,
+            "samples": ["turn on the lights", "lights on"],
+            "lang": "en-US",
+            "skill_id": skill_id,
+        }))
+        self.pipeline.handle_detach_intent(Message("detach_intent", {
+            "intent_name": intent_name,
+        }))
+        container = next(iter(self.pipeline.containers.values()))
+        if skill_id in container.domains:
+            self.assertNotIn(intent_name,
+                             container.domains[skill_id].intent_names)
+        self.assertNotIn(intent_name, self.pipeline.registered_intents)
+
+    def test_detach_skill_removes_all_intents_for_domain(self):
+        skill_id = "chatty.skill"
+        for n, samples in [("hello", ["hello", "hi"]),
+                           ("bye", ["bye", "goodbye"])]:
+            self.pipeline.register_intent(Message("padatious:register_intent", {
+                "name": f"{skill_id}:{n}",
+                "samples": samples,
+                "lang": "en-US",
+                "skill_id": skill_id,
+            }))
+        self.pipeline.handle_detach_skill(Message("detach_skill", {
+            "skill_id": skill_id,
+        }))
+        for intent in (f"{skill_id}:hello", f"{skill_id}:bye"):
+            self.assertNotIn(intent, self.pipeline.registered_intents)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hierarchical.py
+++ b/tests/test_hierarchical.py
@@ -1,0 +1,154 @@
+import tempfile
+import unittest
+from unittest.mock import MagicMock
+
+from ovos_padatious.hierarchical_container import HierarchicalIntentContainer
+from ovos_padatious.match_data import MatchData
+
+
+class TestHierarchicalIntentContainer(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.engine = HierarchicalIntentContainer(cache_dir=self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_add_domain_intent_creates_container(self):
+        self.engine.add_domain_intent("domain1", "intent1", ["sample1", "sample2"])
+        self.assertIn("domain1", self.engine.domains)
+        self.assertIn("intent1", self.engine.domains["domain1"].intent_names)
+
+    def test_add_domain_intent_feeds_classifier(self):
+        self.engine.add_domain_intent("domain1", "intent1", ["sample one"])
+        self.assertIn("domain1", self.engine._dirty_domains)
+        self.engine.train()
+        self.assertIn("domain1", self.engine.domain_engine.intent_names)
+
+    def test_remove_domain(self):
+        self.engine.add_domain_intent("domain1", "intent1", ["sample1"])
+        self.engine.train()
+        self.engine.remove_domain("domain1")
+        self.assertNotIn("domain1", self.engine.domains)
+        self.assertNotIn("domain1", self.engine.domain_engine.intent_names)
+
+    def test_remove_domain_intent(self):
+        self.engine.add_domain_intent("domain1", "intent1", ["sample1"])
+        self.engine.remove_domain_intent("domain1", "intent1")
+        self.assertNotIn("intent1", self.engine.domains["domain1"].intent_names)
+
+    def test_calc_intent_routes_to_classified_domain(self):
+        self.engine.train = MagicMock()
+        self.engine.must_train = False
+        self.engine.domain_engine = MagicMock()
+        self.engine.domain_engine.calc_intent.return_value = MatchData(
+            name="A", sent="q", matches=None, conf=0.9)
+        dom_a, dom_b = MagicMock(), MagicMock()
+        dom_a.calc_intent.return_value = MatchData(name="a", sent="q", matches=None, conf=0.7)
+        dom_b.calc_intent.return_value = MatchData(name="b", sent="q", matches=None, conf=0.95)
+        self.engine.domains["A"] = dom_a
+        self.engine.domains["B"] = dom_b
+        result = self.engine.calc_intent("q")
+        # only the classified domain (A) is scored, not the global argmax (B)
+        self.assertEqual(result.name, "a")
+        dom_b.calc_intent.assert_not_called()
+
+    def test_calc_intent_restricted_to_domain_bypasses_classifier(self):
+        self.engine.train = MagicMock()
+        self.engine.must_train = False
+        self.engine.domain_engine = MagicMock()
+        dom_a = MagicMock()
+        dom_a.calc_intent.return_value = MatchData(name="a", sent="q", matches=None, conf=0.7)
+        self.engine.domains["A"] = dom_a
+        result = self.engine.calc_intent("q", domain="A")
+        self.assertEqual(result.name, "a")
+        self.engine.domain_engine.calc_intent.assert_not_called()
+
+    def test_domain_threshold_rejects_low_confidence(self):
+        self.engine.train = MagicMock()
+        self.engine.must_train = False
+        self.engine.domain_threshold = 0.5
+        self.engine.domain_engine = MagicMock()
+        self.engine.domain_engine.calc_intent.return_value = MatchData(
+            name="A", sent="q", matches=None, conf=0.2)
+        dom_a = MagicMock()
+        self.engine.domains["A"] = dom_a
+        result = self.engine.calc_intent("q")
+        self.assertIsNone(result.name)
+        dom_a.calc_intent.assert_not_called()
+
+    def test_calc_intents_returns_routed_domain_only(self):
+        self.engine.train = MagicMock()
+        self.engine.must_train = False
+        self.engine.domain_engine = MagicMock()
+        self.engine.domain_engine.calc_intent.return_value = MatchData(
+            name="A", sent="q", matches=None, conf=0.9)
+        dom_a = MagicMock()
+        dom_a.calc_intents.return_value = [
+            MatchData(name="a", sent="q", matches=None, conf=0.7)]
+        self.engine.domains["A"] = dom_a
+        result = self.engine.calc_intents("q")
+        self.assertEqual([m.name for m in result], ["a"])
+
+    def test_train_clears_must_train(self):
+        self.engine.add_domain_intent("domain1", "intent1", ["sample1"])
+        self.assertTrue(self.engine.must_train)
+        self.engine.train()
+        self.assertFalse(self.engine.must_train)
+
+
+class TestHierarchicalIntentContainerWithLiveData(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.engine = HierarchicalIntentContainer(cache_dir=self._tmp.name)
+        self.training_data = {
+            "IOT": {
+                "turn_on_device": ["Turn on the lights", "Switch on the fan",
+                                    "Activate the air conditioner"],
+                "turn_off_device": ["Turn off the lights", "Switch off the heater",
+                                     "Deactivate the air conditioner"],
+            },
+            "greetings": {
+                "say_hello": ["Hello", "Hi there", "Good morning"],
+                "say_goodbye": ["Goodbye", "See you later", "Bye"],
+            },
+            "Media Playback": {
+                "play_music": ["Play some music", "Start the playlist", "Play a song"],
+                "stop_music": ["Stop the music", "Pause playback", "Halt the song"],
+            },
+        }
+        for domain, intents in self.training_data.items():
+            for intent, samples in intents.items():
+                self.engine.add_domain_intent(domain, intent, samples)
+        self.engine.train()
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_restricted_domain_match(self):
+        for query, domain, expected in [
+            ("Switch on the fan", "IOT", "turn_on_device"),
+            ("Hi there", "greetings", "say_hello"),
+            ("Play a song", "Media Playback", "play_music"),
+        ]:
+            result = self.engine.calc_intent(query, domain=domain)
+            self.assertEqual(result.name, expected)
+            self.assertGreater(result.conf, 0.8)
+
+    def test_two_stage_routing(self):
+        for query, expected in [
+            ("Turn on the lights", "turn_on_device"),
+            ("Goodbye", "say_goodbye"),
+            ("Play some music", "play_music"),
+        ]:
+            result = self.engine.calc_intent(query)
+            self.assertEqual(result.name, expected)
+            self.assertGreater(result.conf, 0.8)
+
+    def test_calc_domain(self):
+        result = self.engine.calc_domain("turn off the heater")
+        self.assertEqual(result.name, "IOT")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hierarchical_pipeline.py
+++ b/tests/test_hierarchical_pipeline.py
@@ -1,0 +1,119 @@
+"""Tests for the HierarchicalPadatiousPipeline OPM entry point.
+
+Exercises:
+  - the pipeline constructs a HierarchicalIntentContainer.
+  - skill_id is used as the domain when registering intents.
+  - detach via remove_domain_intent (intent detach) and skill detach.
+  - end-to-end two-stage intent matching.
+"""
+import tempfile
+import unittest
+
+from ovos_bus_client.message import Message
+from ovos_utils.messagebus import FakeBus
+
+from ovos_padatious.hierarchical_container import HierarchicalIntentContainer
+from ovos_padatious.opm import HierarchicalPadatiousPipeline
+
+
+def _make_pipeline(cache_dir, **extra):
+    config = {
+        "intent_cache": cache_dir,
+        "single_thread": True,
+        "instant_train": True,
+        "conf_low": 0.5,
+    }
+    config.update(extra)
+    return HierarchicalPadatiousPipeline(FakeBus(), config=config)
+
+
+class TestHierarchicalPadatiousPipeline(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.cache_dir = self._tmp.name
+        self.pipeline = _make_pipeline(self.cache_dir)
+
+    def tearDown(self):
+        self.pipeline.shutdown()
+        self._tmp.cleanup()
+
+    def test_engine_class_is_hierarchical_container(self):
+        self.assertIs(self.pipeline.engine_class, HierarchicalIntentContainer)
+        for c in self.pipeline.containers.values():
+            self.assertIsInstance(c, HierarchicalIntentContainer)
+
+    def test_domain_threshold_propagated(self):
+        pipeline = _make_pipeline(self._tmp.name, domain_threshold=0.4)
+        try:
+            for c in pipeline.containers.values():
+                self.assertEqual(c.domain_threshold, 0.4)
+        finally:
+            pipeline.shutdown()
+
+    def test_skill_id_is_domain_on_register(self):
+        skill_id = "weather.skill"
+        self.pipeline.register_intent(Message("padatious:register_intent", {
+            "name": f"{skill_id}:current",
+            "samples": ["what is the weather", "tell me the weather"],
+            "lang": "en-US",
+            "skill_id": skill_id,
+        }))
+        container = next(iter(self.pipeline.containers.values()))
+        self.assertIn(skill_id, container.domains)
+        self.assertIn(f"{skill_id}:current",
+                      container.domains[skill_id].intent_names)
+
+    def test_intent_matches_via_two_stage_routing(self):
+        for skill_id, name, samples in [
+            ("hello.skill", "hello", ["hello", "hi", "hey there", "good morning"]),
+            ("iot.skill", "lights_on", ["turn on the lights", "lights on",
+                                        "switch on the lights"]),
+        ]:
+            self.pipeline.register_intent(Message("padatious:register_intent", {
+                "name": f"{skill_id}:{name}",
+                "samples": samples,
+                "lang": "en-US",
+                "skill_id": skill_id,
+            }))
+        self.pipeline.train()
+        intent = self.pipeline.calc_intent("turn on the lights", "en-US")
+        self.assertIsNotNone(intent)
+        self.assertEqual(intent.name, "iot.skill:lights_on")
+
+    def test_detach_intent_uses_remove_domain_intent(self):
+        skill_id = "iot.skill"
+        intent_name = f"{skill_id}:lights_on"
+        self.pipeline.register_intent(Message("padatious:register_intent", {
+            "name": intent_name,
+            "samples": ["turn on the lights", "lights on"],
+            "lang": "en-US",
+            "skill_id": skill_id,
+        }))
+        self.pipeline.handle_detach_intent(Message("detach_intent", {
+            "intent_name": intent_name,
+        }))
+        container = next(iter(self.pipeline.containers.values()))
+        if skill_id in container.domains:
+            self.assertNotIn(intent_name,
+                             container.domains[skill_id].intent_names)
+        self.assertNotIn(intent_name, self.pipeline.registered_intents)
+
+    def test_detach_skill_removes_all_intents_for_domain(self):
+        skill_id = "chatty.skill"
+        for n, samples in [("hello", ["hello", "hi"]),
+                           ("bye", ["bye", "goodbye"])]:
+            self.pipeline.register_intent(Message("padatious:register_intent", {
+                "name": f"{skill_id}:{n}",
+                "samples": samples,
+                "lang": "en-US",
+                "skill_id": skill_id,
+            }))
+        self.pipeline.handle_detach_skill(Message("detach_skill", {
+            "skill_id": skill_id,
+        }))
+        for intent in (f"{skill_id}:hello", f"{skill_id}:bye"):
+            self.assertNotIn(intent, self.pipeline.registered_intents)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ovoscope_domain_e2e.py
+++ b/tests/test_ovoscope_domain_e2e.py
@@ -1,0 +1,81 @@
+"""End-to-end tests for DomainPadatiousPipeline using ovoscope.
+
+Mirrors the structure of test_ovoscope_e2e.py but targets the new
+``ovos-padatious-domain-pipeline-plugin`` entry point, which selects
+the DomainIntentContainer-backed pipeline. The skill_id used at
+registration time becomes the domain.
+"""
+import unittest
+
+import pytest
+
+ovoscope = pytest.importorskip("ovoscope", reason="ovoscope not installed; skipping E2E tests")
+
+from ovos_bus_client.message import Message  # noqa: E402
+
+from ovoscope import E2EPipelineHarness  # noqa: E402
+
+from ovos_padatious.domain_container import DomainIntentContainer  # noqa: E402
+from ovos_padatious.opm import DomainPadatiousPipeline  # noqa: E402
+
+PIPELINE_ID = "ovos-padatious-domain-pipeline-plugin"
+CONFIG_KEY = "padatious_domain"
+
+_HELLO_SAMPLES = ["hello", "hi", "hey", "greetings", "good morning"]
+_BYE_SAMPLES = ["goodbye", "bye", "see you later", "farewell", "take care"]
+_LIGHTS_ON_SAMPLES = ["turn on the lights", "switch on lights", "lights on please"]
+
+
+class _DomainPadatiousHarness(E2EPipelineHarness):
+    PIPELINE_ID = PIPELINE_ID
+    CONFIG_KEY = CONFIG_KEY
+    PLUGIN_CONFIG = {"instant_train": True, "conf_low": 0.6}
+    SKILL_ID = "test_skill_padatious_domain"
+
+    pipeline: DomainPadatiousPipeline  # type: ignore[assignment]
+
+    def _register_intent(self, name, samples, lang="en-US"):
+        skill_id = name.split(":", 1)[0]
+        self.bus.emit(Message("padatious:register_intent", {
+            "name": name, "samples": samples, "lang": lang,
+            "skill_id": skill_id,
+        }))
+        import time
+        time.sleep(0.1)
+
+
+class TestDomainPipelineEntryPoint(_DomainPadatiousHarness):
+    def test_engine_is_domain_container(self):
+        for c in self.pipeline.containers.values():
+            self.assertIsInstance(c, DomainIntentContainer)
+
+    def test_exact_utterance_dispatches_intent(self):
+        self._register_intent(f"{self.SKILL_ID}:hello", _HELLO_SAMPLES)
+        msg = self.send_and_capture(
+            "hello", expected_types=[f"{self.SKILL_ID}:hello"], timeout=10.0
+        )
+        self.assertIsNotNone(msg, "expected intent match on bus")
+        self.assertEqual(msg.msg_type, f"{self.SKILL_ID}:hello")
+
+    def test_intents_routed_via_skill_id_domain(self):
+        # Register two skills (= two domains) with disjoint intents.
+        skill_a = "domain_a_skill"
+        skill_b = "domain_b_skill"
+        self._register_intent(f"{skill_a}:hello", _HELLO_SAMPLES)
+        self._register_intent(f"{skill_b}:lights_on", _LIGHTS_ON_SAMPLES)
+
+        container = next(iter(self.pipeline.containers.values()))
+        self.assertIn(skill_a, container.domains)
+        self.assertIn(skill_b, container.domains)
+
+        msg = self.send_and_capture(
+            "turn on the lights",
+            expected_types=[f"{skill_b}:lights_on"],
+            timeout=10.0,
+        )
+        self.assertIsNotNone(msg)
+        self.assertEqual(msg.msg_type, f"{skill_b}:lights_on")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ovoscope_e2e.py
+++ b/tests/test_ovoscope_e2e.py
@@ -68,7 +68,7 @@ class TestRegisteredIntentMatch(_PadatiousHarness):
     def test_exact_utterance_dispatches_intent(self):
         self._register_intent(f"{self.SKILL_ID}:hello", _HELLO_SAMPLES)
         msg = self.send_and_capture(
-            "hello", expected_types=[f"{self.SKILL_ID}:hello"], timeout=10.0
+            "hello", expected_types=[f"{self.SKILL_ID}:hello"], timeout=30.0
         )
         self.assertIsNotNone(msg, "expected intent match on bus")
         self.assertEqual(msg.msg_type, f"{self.SKILL_ID}:hello")
@@ -85,7 +85,7 @@ class TestRegisteredIntentMatch(_PadatiousHarness):
         self._register_intent(f"{self.SKILL_ID}:hello", _HELLO_SAMPLES)
         self._register_intent(f"{self.SKILL_ID}:bye", _BYE_SAMPLES)
         msg = self.send_and_capture(
-            "goodbye", expected_types=[f"{self.SKILL_ID}:bye"], timeout=10.0
+            "goodbye", expected_types=[f"{self.SKILL_ID}:bye"], timeout=30.0
         )
         self.assertIsNotNone(msg)
         self.assertEqual(msg.msg_type, f"{self.SKILL_ID}:bye")
@@ -99,7 +99,7 @@ class TestEntityExtraction(_PadatiousHarness):
             ["buy {item}", "get {item}", "purchase {item}"],
         )
         msg = self.send_and_capture(
-            "buy milk", expected_types=[f"{self.SKILL_ID}:buy"], timeout=10.0
+            "buy milk", expected_types=[f"{self.SKILL_ID}:buy"], timeout=30.0
         )
         self.assertIsNotNone(msg)
         self.assertEqual(msg.msg_type, f"{self.SKILL_ID}:buy")
@@ -109,7 +109,7 @@ class TestDetach(_PadatiousHarness):
     def test_detach_intent_prevents_match(self):
         self._register_intent(f"{self.SKILL_ID}:hello", _HELLO_SAMPLES)
         msg = self.send_and_capture(
-            "hello", expected_types=[f"{self.SKILL_ID}:hello"], timeout=10.0
+            "hello", expected_types=[f"{self.SKILL_ID}:hello"], timeout=30.0
         )
         self.assertIsNotNone(msg)
 
@@ -128,7 +128,7 @@ class TestDetach(_PadatiousHarness):
         msg = self.send_and_capture(
             "turn on the lights",
             expected_types=["skill_b_padatious:lights_on"],
-            timeout=10.0,
+            timeout=30.0,
         )
         self.assertIsNotNone(msg, "skill_b intent should survive skill_a detach")
         detach_skill(self.bus, "skill_b_padatious")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -48,7 +48,7 @@ class UtteranceIntentMatchingTest(unittest.TestCase):
         # regex match
         intent = intent_service.calc_intent("tell me about Mycroft", "en-US")
         self.assertEqual(intent.name, "test2")
-        self.assertEqual(intent.matches, {'thing': 'mycroft'})
+        self.assertEqual(intent.matches, {'thing': 'Mycroft'})
 
         # fuzzy regex match - success
         utterance = "tell me everything about Mycroft"


### PR DESCRIPTION
## Summary

- Adds a new OPM pipeline entry point `ovos-padatious-domain-pipeline-plugin` -> `ovos_padatious.opm:DomainPadatiousPipeline` so the domain-aware engine can be selected at the pipeline level instead of via the `domain_engine: true` config flag.
- The new class subclasses `PadatiousPipeline`, forces `engine_class=DomainIntentContainer`, reads its config from `intents.ovos-padatious-domain-pipeline-plugin` (falls back to `intents.padatious_domain`), and routes registration through `add_domain_intent(skill_id, name, ...)` where `skill_id` IS the domain.
- Refactors `DomainIntentContainer.calc_intent` / `calc_intents` to default to the adapt-style parallel-argmax pattern across all sub-domain containers. The legacy `domain_engine` two-stage router is no longer required for intent selection; `top_k_domains` is kept as an opt-in optimisation hint (default = None, score every domain).
- `domain_engine: true` on the flat pipeline still works for backward compatibility but is marked deprecated (emits `log_deprecation`).
- Tests added: `tests/test_domain_pipeline.py` (unit) and `tests/test_ovoscope_domain_e2e.py` (E2E via ovoscope).
- Docs updated: `README.md` and `docs/ovos_pipeline.md` list both entry points and mark `domain_engine` deprecated.

## Test plan

- [x] pytest tests/test_domain.py tests/test_domain_pipeline.py -- 16 passed locally
- [x] pytest tests/test_pipeline.py tests/test_container.py -- 13 passed locally
- [ ] CI green
- [ ] Ovoscope E2E runs where ovoscope is installed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Domain-backed and hierarchical pipeline variants for domain/skill-based routing and two-stage domain→intent resolution; new benchmarking driver.

* **Documentation**
  * Expanded pipeline, hierarchical pipeline, and benchmark docs; legacy domain flag marked deprecated with migration guidance.

* **Improvements**
  * More robust language/normalization handling, lazy per-domain loading, simplified domain routing and training/cache behavior.

* **Tests**
  * New and updated unit and E2E tests validating domain/hierarchical routing, registration, training, and detach behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenVoiceOS/ovos-padatious-pipeline-plugin/pull/69?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->