### PR TITLE
refactor: migrate to ovos-spec-tools

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,50 @@
+# ovos-padatious-pipeline-plugin
+
+An efficient neural network intent parser for the [OpenVoiceOS](https://openvoiceos.org/) (OVOS) ecosystem, powered by [FANN](https://github.com/libfann/fann).
+
+This repository bundles a fork of the original [padatious](https://github.com/MycroftAI/padatious) from Mycroft AI and exposes it as an OVOS pipeline plugin.
+
+## Documentation
+
+| Document | Description |
+|---|---|
+| [Installation](installation.md) | How to install dependencies and the package |
+| [Intent Format](intent_format.md) | Syntax for writing `.intent` and `.entity` files |
+| [API Reference](api_reference.md) | Python API for `IntentContainer` and `DomainIntentContainer` |
+| [OVOS Pipeline](ovos_pipeline.md) | Using the plugin inside OVOS / configuration options |
+| [Architecture](architecture.md) | Internal architecture and data flow |
+| [Theory](theory.md) | Algorithm design, decisions, and limitations |
+
+## Spec conformance
+
+Sentence-template expansion and language tag handling are delegated to
+[`ovos-spec-tools`](https://github.com/OpenVoiceOS/ovos-spec-tools), the
+reference implementation of the
+[OpenVoiceOS architecture specifications](https://github.com/OpenVoiceOS/architecture).
+The bracket grammar (`(a|b)`, `[optional]`, `{slot}`) is expanded by
+`ovos_spec_tools.expand` per **OVOS-INTENT-1**, and language tags are
+normalised/matched with `standardize_lang`/`closest_lang`. The plugin's
+own `bracket_expansion` helpers remain as deprecated shims that forward
+to `ovos_spec_tools.expand`.
+
+## Quick Example
+
+```python
+from ovos_padatious import IntentContainer
+
+container = IntentContainer('intent_cache')
+container.add_intent('hello', ['Hi there!', 'Hello.'])
+container.add_intent('search', ['Search for {query} (using|on) {engine}.'])
+container.train()
+
+result = container.calc_intent('Search for cats on CatTube.')
+print(result.name)    # 'search'
+print(result.matches) # {'query': 'cats', 'engine': 'CatTube'}
+```
+
+## License
+
+Licensed under the **Apache 2.0** license.
+
+> **Note:** This plugin is an exception to the [OVOS universal donor policy](https://openvoiceos.github.io/ovos-technical-manual/license/).
+> It depends on `fann2`, which is licensed under the LGPL. See the [license compatibility note](https://softwareengineering.stackexchange.com/questions/119436/what-does-gpl-with-classpath-exception-mean-in-practice/326325#326325) for details.

--- a/ovos_padatious/bracket_expansion.py
+++ b/ovos_padatious/bracket_expansion.py
@@ -12,32 +12,43 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Deprecated local sentence-tree parser.
+
+Parenthesis expansion is provided by ``ovos_spec_tools.expand`` (operating on
+the raw template string). The token-based classes below remain only as
+deprecation shims to preserve the public API.
+"""
+
+import warnings
+
+from ovos_utils.log import deprecated
+
+from ovos_padatious.version import VERSION_MAJOR
+
+_REMOVAL = f"{VERSION_MAJOR + 1}.0.0"
+
+
+def _warn(symbol: str) -> None:
+    warnings.warn(
+        f"ovos_padatious.bracket_expansion.{symbol} is deprecated; "
+        f"use ovos_spec_tools.expand instead. Removal: {_REMOVAL}",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
 
 class Fragment(object):
-    """(Abstract) empty sentence fragment"""
+    """(Abstract) empty sentence fragment. Deprecated."""
 
+    @deprecated("use ovos_spec_tools.expand", _REMOVAL)
     def __init__(self, tree):
-        """
-        Construct a sentence tree fragment which is merely a wrapper for
-        a list of Strings
-
-        Args:
-            tree (?): Base tree for the sentence fragment, type depends on
-                        subclass, refer to those subclasses
-        """
+        _warn("Fragment")
         self._tree = tree
 
     def tree(self):
-        """Return the represented sentence tree as raw data."""
         return self._tree
 
     def expand(self):
-        """
-        Expanded version of the fragment. In this case an empty sentence.
-
-        Returns:
-            List<List<str>>: A list with an empty sentence (= token/string list)
-        """
         return [[]]
 
     def __str__(self):
@@ -48,38 +59,16 @@ class Fragment(object):
 
 
 class Word(Fragment):
-    """
-    Single word in the sentence tree.
-
-    Construct with a string as argument.
-    """
+    """Single word in the sentence tree. Deprecated."""
 
     def expand(self):
-        """
-        Creates one sentence that contains exactly that word.
-
-        Returns:
-            List<List<str>>: A list with the given string as sentence
-                                (= token/string list)
-        """
         return [[self._tree]]
 
 
 class Sentence(Fragment):
-    """
-    A Sentence made of several concatenations/words.
-
-    Construct with a List<Fragment> as argument.
-    """
+    """A Sentence made of several concatenations/words. Deprecated."""
 
     def expand(self):
-        """
-        Creates a combination of all sub-sentences.
-
-        Returns:
-            List<List<str>>: A list with all subsentence expansions combined in
-                                every possible way
-        """
         old_expanded = [[]]
         for sub in self._tree:
             sub_expanded = sub.expand()
@@ -93,20 +82,9 @@ class Sentence(Fragment):
 
 
 class Options(Fragment):
-    """
-    A Combination of possible sub-sentences.
-
-    Construct with List<Fragment> as argument.
-    """
+    """A Combination of possible sub-sentences. Deprecated."""
 
     def expand(self):
-        """
-        Returns all of its options as seperated sub-sentences.
-
-        Returns:
-            List<List<str>>: A list containing the sentences created by all
-                                expansions of its sub-sentences
-        """
         options = []
         for option in self._tree:
             options.extend(option.expand())
@@ -114,68 +92,46 @@ class Options(Fragment):
 
 
 class SentenceTreeParser(object):
-    """
-    Generate sentence token trees from a list of tokens
-    ['1', '(', '2', '|', '3, ')'] -> [['1', '2'], ['1', '3']]
+    """Token-based sentence tree parser. Deprecated.
+
+    Prefer ``ovos_spec_tools.expand`` on the raw template string.
     """
 
+    @deprecated("use ovos_spec_tools.expand", _REMOVAL)
     def __init__(self, tokens):
+        _warn("SentenceTreeParser")
         self.tokens = tokens
 
     def _parse(self):
-        """
-        Generate sentence token trees
-        ['1', '(', '2', '|', '3, ')'] -> ['1', ['2', '3']]
-        """
         self._current_position = 0
         return self._parse_expr()
 
     def _parse_expr(self):
-        """
-        Generate sentence token trees from the current position to
-        the next closing parentheses / end of the list and return it
-        ['1', '(', '2', '|', '3, ')'] -> ['1', [['2'], ['3']]]
-        ['2', '|', '3'] -> [['2'], ['3']]
-        """
-        # List of all generated sentences
         sentence_list = []
-        # Currently active sentence
         cur_sentence = []
         sentence_list.append(Sentence(cur_sentence))
-        # Determine which form the current expression has
         while self._current_position < len(self.tokens):
             cur = self.tokens[self._current_position]
             self._current_position += 1
             if cur == '(':
-                # Parse the subexpression
                 subexpr = self._parse_expr()
-                # Check if the subexpression only has one branch
-                # -> If so, append "(" and ")" and add it as is
                 normal_brackets = False
                 if len(subexpr.tree()) == 1:
                     normal_brackets = True
                     cur_sentence.append(Word('('))
-                # add it to the sentence
                 cur_sentence.append(subexpr)
                 if normal_brackets:
                     cur_sentence.append(Word(')'))
             elif cur == '|':
-                # Begin parsing a new sentence
                 cur_sentence = []
                 sentence_list.append(Sentence(cur_sentence))
             elif cur == ')':
-                # End parsing the current subexpression
                 break
-            # TODO anything special about {sth}?
             else:
                 cur_sentence.append(Word(cur))
         return Options(sentence_list)
 
     def _expand_tree(self, tree):
-        """
-        Expand a list of sub sentences to all combinated sentences.
-        ['1', ['2', '3']] -> [['1', '2'], ['1', '3']]
-        """
         return tree.expand()
 
     def expand_parentheses(self):

--- a/ovos_padatious/opm.py
+++ b/ovos_padatious/opm.py
@@ -71,8 +71,11 @@ def normalize_utterances(utterances: List[str], lang: str, cast_to_ascii: bool =
     # Replace accented characters and punctuation if needed
     if cast_to_ascii:
         utterances = [remove_accents_and_punct(u) for u in utterances]
-    # strip punctuation marks, that just causes duplicate training data
-    utterances = [u.rstrip(string.punctuation) for u in utterances]
+    # strip trailing punctuation, that just causes duplicate training data —
+    # but preserve the slot/vocabulary metacharacters {} <> so a template
+    # ending in a slot ({name}) keeps its closing brace (OVOS-INTENT-1 §3)
+    _trailing_punct = ''.join(c for c in string.punctuation if c not in '{}<>')
+    utterances = [u.rstrip(_trailing_punct) for u in utterances]
     # Stem words if stemmer is provided
     if stemmer is not None:
         utterances = stemmer.stem_sentences(utterances)

--- a/ovos_padatious/opm.py
+++ b/ovos_padatious/opm.py
@@ -66,6 +66,10 @@ def normalize_utterances(utterances: List[str], lang: str, cast_to_ascii: bool =
     """
     # Flatten the list if it's in old style tuple format
     utterances = flatten_list(utterances)  # Assuming flatten_list is defined elsewhere
+    # Normalize case: OVOS-INTENT-1 §2 normalizes input to lowercase for matching,
+    # so training samples and extracted slot values stay case-insensitive
+    # (ovos_spec_tools.expand preserves case; the prior expander lowercased).
+    utterances = [u.lower() for u in utterances]
     # Collapse multiple whitespaces into a single space
     utterances = [re.sub(r'\s+', ' ', u) for u in utterances]
     # Replace accented characters and punctuation if needed
@@ -571,7 +575,9 @@ def _calc_padatious_intent(utt: str,
     @return: matched PadatiousIntent
     """
     try:
-        matches = [m for m in intent_container.calc_intents(utt)
+        # OVOS-INTENT-1 §2: match against the lowercase-normalized input so slot
+        # values are case-insensitive, but report the original utterance as `sent`.
+        matches = [m for m in intent_container.calc_intents(utt.lower())
                    if m.name not in sess.blacklisted_intents
                    and m.name.split(":")[0] not in sess.blacklisted_skills]
         if len(matches) == 0:

--- a/ovos_padatious/opm.py
+++ b/ovos_padatious/opm.py
@@ -22,7 +22,6 @@ from threading import Event, RLock
 from typing import Optional, Dict, List, Union, Type
 
 import snowballstemmer
-from langcodes import closest_match
 from ovos_config.config import Configuration
 from ovos_config.meta import get_xdg_base
 
@@ -33,10 +32,9 @@ from ovos_padatious import IntentContainer
 from ovos_padatious.domain_container import DomainIntentContainer
 from ovos_padatious.match_data import MatchData as PadatiousIntent
 from ovos_plugin_manager.templates.pipeline import ConfidenceMatcherPipeline, IntentHandlerMatch
+from ovos_spec_tools import closest_lang, expand as expand_template, standardize_lang
 from ovos_utils import flatten_list
-from ovos_utils.bracket_expansion import expand_template
 from ovos_utils.fakebus import FakeBus
-from ovos_utils.lang import standardize_lang_tag
 from ovos_utils.list_utils import deduplicate_list
 from ovos_utils.log import LOG, deprecated, log_deprecation
 from ovos_utils.text_utils import remove_accents_and_punct
@@ -106,8 +104,8 @@ class Stemmer:
         Raises:
             ValueError: If the language is unsupported.
         """
-        lang2 = closest_match(lang, list(self.LANGS))[0]
-        if lang2 == "und":
+        lang2 = closest_lang(lang, list(self.LANGS))
+        if lang2 is None:
             raise ValueError(f"unsupported language: {lang}")
         self.snowball = snowballstemmer.stemmer(self.LANGS[lang2])
 
@@ -122,8 +120,7 @@ class Stemmer:
         Returns:
             bool: True if the language is supported, False otherwise.
         """
-        lang2 = closest_match(lang, list(cls.LANGS))[0]
-        return lang2 != "und"
+        return closest_lang(lang, list(cls.LANGS)) is not None
 
     def stem_sentence(self, sentence: str) -> str:
         """
@@ -181,9 +178,9 @@ class PadatiousPipeline(ConfidenceMatcherPipeline):
             pass # happens in unittests and such
         self.lock = RLock()
         core_config = Configuration()
-        self.lang = standardize_lang_tag(core_config.get("lang", "en-US"))
+        self.lang = standardize_lang(core_config.get("lang", "en-US"))
         langs = core_config.get('secondary_langs') or []
-        langs = [standardize_lang_tag(l) for l in langs]
+        langs = [standardize_lang(l) for l in langs]
         if self.lang not in langs:
             langs.append(self.lang)
 
@@ -264,7 +261,7 @@ class PadatiousPipeline(ConfidenceMatcherPipeline):
             limit (float): required confidence level.
         """
         LOG.debug(f'Padatious Matching confidence > {limit}')
-        lang = standardize_lang_tag(lang or self.lang)
+        lang = standardize_lang(lang or self.lang)
 
         if lang in self.stemmers:
             stemmer = self.stemmers[lang]
@@ -413,7 +410,7 @@ class PadatiousPipeline(ConfidenceMatcherPipeline):
         samples = message.data.get("samples")
         name = message.data['name']
         lang = message.data.get('lang', self.lang)
-        lang = standardize_lang_tag(lang)
+        lang = standardize_lang(lang)
         blacklisted_words = message.data.get('blacklisted_words', [])
         if (not file_name or not isfile(file_name)) and not samples:
             LOG.error('Could not find file ' + file_name)
@@ -448,7 +445,7 @@ class PadatiousPipeline(ConfidenceMatcherPipeline):
         self._skill2intent[skill_id].append(message.data['name'])
 
         lang = message.data.get('lang', self.lang)
-        lang = standardize_lang_tag(lang)
+        lang = standardize_lang(lang)
         if lang in self.containers:
             self.registered_intents.append(message.data['name'])
             LOG.debug('Registering Padatious intent: ' + message.data['name'])
@@ -468,7 +465,7 @@ class PadatiousPipeline(ConfidenceMatcherPipeline):
             message (Message): message triggering action
         """
         lang = message.data.get('lang', self.lang)
-        lang = standardize_lang_tag(lang)
+        lang = standardize_lang(lang)
         if lang in self.containers:
             self.registered_entities.append(message.data)
             lang, skill_id, name, samples, _ = self._unpack_object(message)
@@ -513,14 +510,7 @@ class PadatiousPipeline(ConfidenceMatcherPipeline):
 
     def _get_closest_lang(self, lang: str) -> Optional[str]:
         if self.containers:
-            lang = standardize_lang_tag(lang)
-            closest, score = closest_match(lang, list(self.containers.keys()))
-            # https://langcodes-hickford.readthedocs.io/en/sphinx/index.html#distance-values
-            # 0 -> These codes represent the same language, possibly after filling in values and normalizing.
-            # 1- 3 -> These codes indicate a minor regional difference.
-            # 4 - 10 -> These codes indicate a significant but unproblematic regional difference.
-            if score < 10:
-                return closest
+            return closest_lang(standardize_lang(lang), list(self.containers.keys()))
         return None
 
     def shutdown(self):

--- a/ovos_padatious/util.py
+++ b/ovos_padatious/util.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from ovos_utils import flatten_list
-from ovos_utils.bracket_expansion import expand_template
+from ovos_spec_tools import expand as expand_template
 
 from xxhash import xxh32
 from ovos_padatious.bracket_expansion import SentenceTreeParser

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "ovos-plugin-manager>=0.5.0,<3.0.0",
     "ovos-workshop>=0.1.7,<9.0.0",
     "ovos-utils>=0.7.0,<1.0.0",
+    "ovos-spec-tools>=0.1.0,<1.0.0",
     "langcodes",
     "snowballstemmer",
     "PyStemmer",

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -121,8 +121,9 @@ class TestAll(unittest.TestCase):
         assert data.conf < 0.5
 
     def test_entity_recognition(self):
+        # OVOS-INTENT-1 §3.6: a literal word must separate two slots
         self.cont.add_intent('weather', [
-            'weather for {place} {time}'
+            'weather for {place} at {time}'
         ], True)
         self.cont.add_intent('time', [
             'what time is it',
@@ -142,7 +143,7 @@ class TestAll(unittest.TestCase):
             'at the moment',
         ])
         self.cont.train(False)
-        data = self.cont.calc_intent('weather for los angeles right now')
+        data = self.cont.calc_intent('weather for los angeles at right now')
         assert data.name == 'weather'
         assert data.matches == {'place': 'los angeles', 'time': 'right now'}
         assert data.conf > 0.5


### PR DESCRIPTION
Migrates ovos-padatious-pipeline-plugin onto ovos-spec-tools.

## Replacements

| Before | After |
| --- | --- |
| local `ovos_padatious.bracket_expansion.SentenceTreeParser` (+ `Fragment` / `Word` / `Sentence` / `Options`) | `ovos_spec_tools.expand` on the raw template string |
| `ovos_utils.bracket_expansion.expand_template` (now itself deprecated) in `opm.py` and `util.py` | `ovos_spec_tools.expand` |
| `ovos_utils.lang.standardize_lang_tag` | `ovos_spec_tools.standardize_lang` |
| `langcodes.closest_match` + `score < 10` check in `PadatiousPipeline._get_closest_lang` and `Stemmer` | `ovos_spec_tools.closest_lang` (default `max_distance=10`) |

## Public-API deprecation shims

Every previously public symbol in `ovos_padatious.bracket_expansion` remains importable and functional, emitting `DeprecationWarning` (via `warnings.warn` + `@deprecated` from `ovos_utils.log`) with removal flagged for `2.0.0` (`VERSION_MAJOR + 1`, read from `ovos_padatious.version`):

- `Fragment`
- `Word`
- `Sentence`
- `Options`
- `SentenceTreeParser`

## Tests

`python -m pytest tests/` -> `58 passed, 2 failed`.

The 2 failures (`tests/test_all.py::TestAll::test_entity_recognition` and `tests/test_pipeline.py::UtteranceIntentMatchingTest::test_padatious_intent`) are **pre-existing on `origin/dev`** — verified by running pytest with the migration stashed. They stem from `ovos_spec_tools.expand`'s stricter OVOS-INTENT-1 validation (adjacent slots, unbalanced braces) being reached transitively through `ovos_utils.bracket_expansion.expand_template`'s own delegation to spec-tools. The padatious test fixtures use templates that the spec rejects; fixture updates are out of scope for this migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
