### PR TITLE
feat: enforce OVOS-CONTEXT-1 requires/excludes_context gating at match time

### DIFF
--- a/ovos_padatious/opm.py
+++ b/ovos_padatious/opm.py
@@ -34,6 +34,7 @@ from ovos_padatious.match_data import MatchData as PadatiousIntent
 from ovos_plugin_manager.templates.pipeline import ConfidenceMatcherPipeline, IntentHandlerMatch
 from ovos_spec_tools import closest_lang, expand as expand_template, standardize_lang
 from ovos_spec_tools import SpecMessage
+from ovos_spec_tools import gate_satisfied
 from ovos_utils import flatten_list
 from ovos_utils.fakebus import FakeBus
 from ovos_utils.list_utils import deduplicate_list
@@ -245,6 +246,14 @@ class PadatiousPipeline(ConfidenceMatcherPipeline):
         # holds the subset currently suppressed.
         self._intent_definitions = {}
         self._disabled_intents = {}
+
+        # OVOS-CONTEXT-1 §6/§6.1 requires_context / excludes_context gating.
+        # Registration MAY carry these declarations; they are stored per
+        # registered intent (keyed by the internal ``<skill_id>:<name>``) and
+        # evaluated at match time via the shared ``gate_satisfied`` helper.
+        # Retained across the disable/enable lifecycle (mirrors
+        # _intent_definitions); dropped only on deregister.
+        self._intent_context_gates = {}
 
         # legacy registration contract (kept for back-compat)
         self.bus.on('padatious:register_intent', self.register_intent)
@@ -475,6 +484,14 @@ class PadatiousPipeline(ConfidenceMatcherPipeline):
         # the intent after a disable detached it
         self._intent_definitions[message.data['name']] = message
 
+        # OVOS-CONTEXT-1 §6: retain any requires/excludes gating declarations
+        # keyed by the internal intent name. Only stored when present so
+        # intents without a gate keep unchanged (ungated) behavior.
+        requires = message.data.get("requires_context")
+        excludes = message.data.get("excludes_context")
+        if requires or excludes:
+            self._intent_context_gates[message.data['name']] = (requires, excludes)
+
         lang = message.data.get('lang', self.lang)
         lang = standardize_lang(lang)
         if lang in self.containers:
@@ -557,7 +574,11 @@ class PadatiousPipeline(ConfidenceMatcherPipeline):
             "padatious:register_intent",
             data={"name": full, "samples": list(samples), "lang": lang,
                   "skill_id": skill_id,
-                  "blacklisted_words": message.data.get("blacklist", [])},
+                  "blacklisted_words": message.data.get("blacklist", []),
+                  # OVOS-CONTEXT-1 §6: forward the optional gating declarations
+                  # onto the internal registration so they are stored per intent.
+                  "requires_context": message.data.get("requires_context"),
+                  "excludes_context": message.data.get("excludes_context")},
             context=dict(message.context, skill_id=skill_id))
         self.register_intent(legacy)
 
@@ -599,6 +620,7 @@ class PadatiousPipeline(ConfidenceMatcherPipeline):
         for full in self._spec_intent_names(message):
             self.__detach_intent(full)
             self._disabled_intents.pop(full, None)
+            self._intent_context_gates.pop(full, None)
         _calc_padatious_intent.cache_clear()
         if self.config.get("instant_train", False):
             self.train(message)
@@ -631,6 +653,7 @@ class PadatiousPipeline(ConfidenceMatcherPipeline):
         for full in list(self._skill2intent.get(skill_id, [])):
             self.__detach_intent(full)
             self._disabled_intents.pop(full, None)
+            self._intent_context_gates.pop(full, None)
         # drop the skill's entities too
         prefix = f"{skill_id}:"
         for lang in self.containers:
@@ -713,6 +736,25 @@ class PadatiousPipeline(ConfidenceMatcherPipeline):
                                           blacklisted_intents, blacklisted_skills)
                    for utt in utterances]
         intents = [i for i in intents if i is not None]
+        # OVOS-CONTEXT-1 §6/§6.1: drop any candidate whose requires/excludes
+        # gating is not satisfied against the session's intent_context. The
+        # shared helper handles liveness/scope/decay; owner_id is the intent's
+        # skill_id (the private-scope default owner). Ungated intents pass.
+        if intents and self._intent_context_gates:
+            intent_context = getattr(sess, "intent_context", None) or {}
+            kept = []
+            for i in intents:
+                gate = self._intent_context_gates.get(i.name)
+                if gate is not None:
+                    requires, excludes = gate
+                    owner_id = i.name.split(":")[0]
+                    if not gate_satisfied(intent_context, requires, excludes,
+                                          owner_id=owner_id):
+                        LOG.debug(f"Padatious intent '{i.name}' dropped: "
+                                  f"OVOS-CONTEXT-1 gating not satisfied")
+                        continue
+                kept.append(i)
+            intents = kept
         # select best
         if intents:
             return max(intents, key=lambda k: k.conf)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     # prerelease floor to let pip resolve .[test] without --pre.
     "ovos-plugin-manager>=2.3.0a1,<3.0.0",
     "ovos-utils>=0.7.0,<1.0.0",
-    "ovos-spec-tools>=0.16.1a2",
+    "ovos-spec-tools>=1.4.0a1",
     "langcodes",
     "snowballstemmer",
     "PyStemmer",
@@ -42,7 +42,7 @@ test = [
     "pytest-cov",
     # INTENT-4 consumer e2e stack floor. Mirrors ovos-test-harness@dev.
     "ovos-bus-client>=2.5.1a1,<3.0.0",
-    "ovos-spec-tools>=0.16.1a2",
+    "ovos-spec-tools>=1.4.0a1",
 ]
 
 [project.urls]

--- a/tests/test_context_gating.py
+++ b/tests/test_context_gating.py
@@ -1,0 +1,138 @@
+# Copyright 2020 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Tests for OVOS-CONTEXT-1 requires_context / excludes_context gating.
+
+The padatious pipeline stores the optional gating declarations at
+registration time (keyed by the internal ``<skill_id>:<name>``) and drops
+gated candidates at match time via the shared ``gate_satisfied`` helper.
+
+These tests exercise the gate in isolation by stubbing the container match
+(``_calc_padatious_intent``), so no trained fann2 model is required.
+"""
+from unittest import TestCase, mock
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session
+from ovos_spec_tools import SpecMessage
+
+import ovos_padatious.opm as opm
+from ovos_padatious.match_data import MatchData
+from ovos_padatious.opm import PadatiousPipeline
+
+
+SKILL = "context.skill"
+INTENT = "guarded"
+FULL = f"{SKILL}:{INTENT}"
+
+
+def template_msg(requires=None, excludes=None):
+    """Build an ovos.intent.register.template payload with optional gates."""
+    data = {"skill_id": SKILL, "intent_name": INTENT, "lang": "en-US",
+            "samples": ["do the guarded thing"]}
+    if requires is not None:
+        data["requires_context"] = requires
+    if excludes is not None:
+        data["excludes_context"] = excludes
+    return Message(SpecMessage.INTENT_REGISTER_TEMPLATE, data,
+                   {"skill_id": SKILL})
+
+
+def utter_msg(intent_context):
+    """An utterance message carrying a session with the given intent_context."""
+    sess = Session("sess-ctx")
+    sess.intent_context = dict(intent_context)
+    return Message("recognizer_loop:utterance", {},
+                   {"session": sess.serialize()})
+
+
+class TestContextGating(TestCase):
+    def setUp(self):
+        self.pipeline = PadatiousPipeline(mock.Mock())
+
+    # ---- storage ----------------------------------------------------- #
+
+    def test_requires_context_stored_on_register(self):
+        """A template registration retains its requires_context declaration."""
+        self.pipeline.handle_register_template(template_msg(requires=["mode"]))
+        self.assertIn(FULL, self.pipeline._intent_context_gates)
+        requires, excludes = self.pipeline._intent_context_gates[FULL]
+        self.assertEqual(requires, ["mode"])
+        self.assertIsNone(excludes)
+
+    def test_no_gate_not_stored(self):
+        """An ungated registration adds no gate entry (unchanged behavior)."""
+        self.pipeline.handle_register_template(template_msg())
+        self.assertNotIn(FULL, self.pipeline._intent_context_gates)
+
+    def test_gate_dropped_on_deregister(self):
+        """Deregistering an intent drops its retained gate."""
+        self.pipeline.handle_register_template(template_msg(requires=["mode"]))
+        self.pipeline.handle_deregister_intent_spec(
+            Message(SpecMessage.INTENT_DEREGISTER,
+                    {"skill_id": SKILL, "intent_name": INTENT},
+                    {"skill_id": SKILL}))
+        self.assertNotIn(FULL, self.pipeline._intent_context_gates)
+
+    # ---- enforcement (container match stubbed) ----------------------- #
+
+    def _stub_match(self, conf=0.9):
+        """Patch the container match so calc_intent yields our candidate."""
+        candidate = MatchData(FULL, "do the guarded thing", matches={}, conf=conf)
+        patcher = mock.patch.object(opm, "_calc_padatious_intent",
+                                    return_value=candidate)
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+    def test_requires_context_present_matches(self):
+        """requires_context satisfied by a live private entry => candidate kept."""
+        self.pipeline.handle_register_template(template_msg(requires=["mode"]))
+        self._stub_match()
+        # private scope default => stored key is "<skill_id>:mode"
+        msg = utter_msg({f"{SKILL}:mode": {"value": True}})
+        result = self.pipeline.calc_intent("do the guarded thing", "en-US", msg)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.name, FULL)
+
+    def test_requires_context_absent_drops(self):
+        """requires_context with no matching entry => candidate dropped."""
+        self.pipeline.handle_register_template(template_msg(requires=["mode"]))
+        self._stub_match()
+        msg = utter_msg({})  # empty context, gate unsatisfied
+        result = self.pipeline.calc_intent("do the guarded thing", "en-US", msg)
+        self.assertIsNone(result)
+
+    def test_excludes_context_present_drops(self):
+        """excludes_context present as a live entry => candidate dropped."""
+        self.pipeline.handle_register_template(template_msg(excludes=["busy"]))
+        self._stub_match()
+        msg = utter_msg({f"{SKILL}:busy": {"value": True}})
+        result = self.pipeline.calc_intent("do the guarded thing", "en-US", msg)
+        self.assertIsNone(result)
+
+    def test_excludes_context_absent_matches(self):
+        """excludes_context absent => candidate kept."""
+        self.pipeline.handle_register_template(template_msg(excludes=["busy"]))
+        self._stub_match()
+        msg = utter_msg({})
+        result = self.pipeline.calc_intent("do the guarded thing", "en-US", msg)
+        self.assertIsNotNone(result)
+
+    def test_ungated_intent_unaffected(self):
+        """An intent without gates matches regardless of context."""
+        self.pipeline.handle_register_template(template_msg())
+        self._stub_match()
+        msg = utter_msg({})
+        result = self.pipeline.calc_intent("do the guarded thing", "en-US", msg)
+        self.assertIsNotNone(result)


### PR DESCRIPTION
## What

Adopts **OVOS-CONTEXT-1** `requires_context` / `excludes_context` gating in the padatious pipeline, using the **shared** helper `from ovos_spec_tools import gate_satisfied` (`ovos_spec_tools.context`).

### Contract
- Registration MAY carry optional `requires_context` and `excludes_context`, each a list of bare-string keys or `{"key","scope":"private"|"shared"}` mappings (default private). They arrive on the INTENT-4 `ovos.intent.register.template` payload and the legacy `padatious:register_intent`.
- Stored per registered intent keyed by the internal `<skill_id>:<name>`, retained across the disable/enable lifecycle (mirrors `_intent_definitions`) and dropped on deregister/skill-deregister.
- At match time, each produced candidate is dropped when `gate_satisfied(sess.intent_context or {}, requires, excludes, owner_id=skill_id)` returns False. `owner_id` is the intent's `skill_id`. The helper handles liveness / scope / decay internally.
- **Additive**: no requires/excludes => unchanged behavior.

### Key locations
- Storage: `register_intent` (`_intent_context_gates`) + propagation through `handle_register_template`; cleanup in the deregister handlers.
- Enforcement: candidate filter in `calc_intent`.

## Testing
- New `tests/test_context_gating.py` (8 tests): storage present-vs-absent, deregister cleanup, requires present/absent gate, excludes present/absent, ungated unaffected. Container match is stubbed so no trained fann2 model is needed.
- Fresh uv venv: new tests + existing `test_intent_4.py` / `test_pipeline.py` all green.

## Dependency note
`ovos-spec-tools` floor raised to `>=1.4.0a1` — the gating helpers (`gate_satisfied`) live on the unpublished spec-tools branch `feat/context-1-gating-helpers` (currently `1.2.2a1`); the published `1.3.0a1` predates them, so the floor targets the next feat alpha (`1.4.0a1`) that will carry the helper on merge. Adjust if the actual published version differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)