### PR TITLE
fix: forward blacklisted_words to add_intent by keyword

### DIFF
--- a/ovos_padatious/opm.py
+++ b/ovos_padatious/opm.py
@@ -499,9 +499,11 @@ class PadatiousPipeline(ConfidenceMatcherPipeline):
             LOG.debug('Registering Padatious intent: ' + message.data['name'])
             lang, skill_id, name, samples, blacklisted_words = self._unpack_object(message)
             if self.engine_class == DomainIntentContainer:
-                self.containers[lang].add_domain_intent(skill_id, name, samples, blacklisted_words)
+                self.containers[lang].add_domain_intent(skill_id, name, samples,
+                                                        blacklisted_words=blacklisted_words)
             else:
-                self.containers[lang].add_intent(name, samples, blacklisted_words)
+                self.containers[lang].add_intent(name, samples,
+                                                 blacklisted_words=blacklisted_words)
 
         if self.config.get("instant_train", False) or self.first_train.is_set():
             self.train(message)

--- a/tests/test_register_blacklist.py
+++ b/tests/test_register_blacklist.py
@@ -1,0 +1,64 @@
+# Copyright 2020 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Engine-level ``blacklisted_words`` registration.
+
+A registered intent carries an optional ``blacklisted_words`` list. The
+pipeline must forward it to ``IntentContainer.add_intent`` by keyword so it
+reaches the container's per-intent blacklist; an utterance containing a
+blacklisted word is then dropped at match time.
+"""
+from unittest import TestCase, mock
+
+from ovos_bus_client.message import Message
+
+from ovos_padatious.opm import PadatiousPipeline
+
+SKILL = "blacklist.skill"
+NAME = f"{SKILL}:forbidden"
+LANG = "en-US"
+BLACKLIST = ["bad", "404"]
+
+
+def register_msg(blacklisted_words):
+    data = {"skill_id": SKILL, "name": NAME, "lang": LANG,
+            "samples": ["this is a test", "another test"],
+            "blacklisted_words": blacklisted_words}
+    return Message("padatious:register_intent", data, {"skill_id": SKILL})
+
+
+class TestRegisterBlacklist(TestCase):
+    def setUp(self):
+        self.pipeline = PadatiousPipeline(mock.Mock())
+
+    def test_blacklisted_words_reach_container(self):
+        """The list must land in the container's blacklist, not reload_cache."""
+        self.pipeline.register_intent(register_msg(BLACKLIST))
+        container = self.pipeline.containers[LANG]
+        self.assertEqual(container.blacklisted_words[NAME], BLACKLIST)
+
+    def test_blacklisted_utterance_dropped(self):
+        """A trained intent does not match an utterance with a blacklisted word."""
+        self.pipeline.register_intent(register_msg(BLACKLIST))
+        container = self.pipeline.containers[LANG]
+        container.train(single_thread=True, timeout=120)
+        matches = container.calc_intents("this is a bad test")
+        self.assertEqual([m for m in matches if m.name == NAME], [])
+
+    def test_clean_utterance_still_matches(self):
+        """Without a blacklisted word the same intent still matches."""
+        self.pipeline.register_intent(register_msg(BLACKLIST))
+        container = self.pipeline.containers[LANG]
+        container.train(single_thread=True, timeout=120)
+        self.assertEqual(container.calc_intent("this is another test").name, NAME)


### PR DESCRIPTION
## Problem

`PadatiousPipeline.register_intent` called `IntentContainer.add_intent(name, samples, blacklisted_words)` passing `blacklisted_words` **positionally**. The container signature is:

```python
add_intent(name, lines, reload_cache=False, must_train=True, blacklisted_words=None)
```

So the blacklist list landed in `reload_cache` and `blacklisted_words` stayed `None` — engine-level `voc_blacklist` / `blacklisted_words` was silently dropped and never enforced at match time.

## Fix

Pass `blacklisted_words=...` by keyword in `register_intent`, for both the flat `add_intent` and the `DomainIntentContainer.add_domain_intent` branch. Container signatures are unchanged.

## Scope

- `add_entity` / `add_domain_entity` take no blacklist arg — unaffected.
- The OVOS-CONTEXT-1 / INTENT-2 `slot_blacklist` path stores into a separate dict at registration and enforces at match time; it never routes through `add_intent`, so it was not affected by this positional mistake.

## Tests

`tests/test_register_blacklist.py` registers an intent with `blacklisted_words` through the real pipeline + a real trained `IntentContainer` (fann2) and asserts the list reaches the container blacklist, a blacklisted utterance is dropped, and a clean utterance still matches. Red before the fix, green after. Full unit suite: 72 passed, 2 skipped (pre-existing ovoscope e2e skips).

This un-breaks engine-level `voc_blacklist`, so skills no longer need handler-level blacklist enforcement — skills keeping it remains fine (back-compat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Intent registration now correctly handles optional blacklisted words, improving how restricted terms are applied during matching.
  * Utterances containing blacklisted words are no longer matched to the corresponding intent, while valid utterances still work as expected.

* **Tests**
  * Added coverage for intent registration and matching behavior when blacklisted words are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->