### PR TITLE
fix: session blacklist bypassed by the legacy/INTENT-4 intent-name alias

### DIFF
--- a/ovos_padatious/intent_container.py
+++ b/ovos_padatious/intent_container.py
@@ -147,7 +147,7 @@ class IntentContainer:
             reload_cache (bool): Whether to ignore cached intent.
             must_train (bool): Whether the model needs training after adding the intent.
         """
-        self.blacklisted_words[name] += blacklisted_words or []
+        self.blacklisted_words[name] = blacklisted_words or []
         self.intents.add(name, lines, reload_cache, must_train)
         if self.padaos is not None:
             self.padaos.add_intent(name, lines)

--- a/ovos_padatious/opm.py
+++ b/ovos_padatious/opm.py
@@ -407,6 +407,10 @@ class PadatiousPipeline(ConfidenceMatcherPipeline):
         Args:
             intent_name (str): intent identifier
         """
+        # Detach/removal must key off the same canonical name registration
+        # collapsed onto, so unregistering by either the legacy `.intent`
+        # alias or the OVOS-INTENT-4 canonical id works (ovos-core#831).
+        intent_name = _dealias_intent_name(intent_name)
         if intent_name in self.registered_intents:
             self.registered_intents.remove(intent_name)
             for lang in self.containers:
@@ -496,7 +500,17 @@ class PadatiousPipeline(ConfidenceMatcherPipeline):
             LOG.warning("Skill ID is missing. Registering under 'anonymous_skill'")
             skill_id = message.data["skill_id"] = "anonymous_skill"
 
-        self._skill2intent[skill_id].append(message.data['name'])
+        # ovos-workshop >= 9.3 dual-registers one logical intent under both
+        # the legacy ``padatious:register_intent`` contract (name suffixed
+        # ``.intent``) and the OVOS-INTENT-4 spec contract (suffix-less,
+        # routed here via handle_register_template). Collapse the alias to
+        # the canonical name HERE, at registration time, so both wire
+        # messages index a single engine entry instead of two matchable
+        # duplicates (ovos-core#831). This plugin owns its own back-compat.
+        message.data['name'] = _dealias_intent_name(message.data['name'])
+
+        if message.data['name'] not in self._skill2intent[skill_id]:
+            self._skill2intent[skill_id].append(message.data['name'])
         # retain the registration so an INTENT-4 enable (§8.5) can re-train
         # the intent after a disable detached it
         self._intent_definitions[message.data['name']] = message
@@ -532,7 +546,8 @@ class PadatiousPipeline(ConfidenceMatcherPipeline):
         lang = message.data.get('lang', self.lang)
         lang = standardize_lang(lang)
         if lang in self.containers:
-            self.registered_intents.append(message.data['name'])
+            if message.data['name'] not in self.registered_intents:
+                self.registered_intents.append(message.data['name'])
             LOG.debug('Registering Padatious intent: ' + message.data['name'])
             lang, skill_id, name, samples, blacklisted_words = self._unpack_object(message)
             if self.engine_class == DomainIntentContainer:
@@ -917,6 +932,56 @@ class PadatiousPipeline(ConfidenceMatcherPipeline):
             {"entities": self.registered_entities}))
 
 
+def _dealias_intent_name(name: Optional[str]) -> Optional[str]:
+    """Fold the legacy ``<skill_id>:<file>.intent`` id onto the OVOS-INTENT-4
+    canonical ``<skill_id>:<file>`` id.
+
+    ovos-workshop >= 9.3 dual-registers one skill capability under both wire
+    forms during the INTENT-4 migration (the legacy ``padatious:register_intent``
+    contract and the spec ``ovos.intent.register.template`` contract, whose
+    ``intent_name`` already has the ``.intent`` suffix stripped). This plugin
+    folds that onto one canonical engine entry at REGISTRATION time (see
+    ``PadatiousPipeline.register_intent`` / ``__detach_intent``), so engine
+    matches (``m.name``) are canonical by construction.
+
+    This helper is also used to canonicalize session ``blacklisted_intents``
+    entries, since old sessions/configs may still carry the legacy
+    ``.intent``-suffixed id (ovos-core#831; OVOS-PIPELINE-1 §5.4).
+    """
+    if name and name.endswith(".intent"):
+        return name[:-len(".intent")]
+    return name
+
+
+# Legacy `.intent`-suffixed blacklist entries are deprecated compat, not a
+# stable contract. Warn once per distinct offending entry (not per utterance)
+# so stale mycroft.conf/session config gets flagged without spamming the log.
+_warned_legacy_blacklist_entries = set()
+
+
+def _canonicalize_blacklist(blacklisted_intents: frozenset) -> frozenset:
+    """Canonicalize legacy `.intent`-suffixed session blacklist entries.
+
+    Sessions/config may still list intents by the legacy
+    ``<skill_id>:<file>.intent`` id. Engine matches are canonical by
+    construction (registration-time alias collapse), so the blacklist must be
+    normalized to compare correctly. Logs a one-time deprecation warning per
+    distinct legacy entry pointing at the canonical replacement.
+    """
+    canonical = set()
+    for b in blacklisted_intents:
+        c = _dealias_intent_name(b)
+        canonical.add(c)
+        if c != b and b not in _warned_legacy_blacklist_entries:
+            _warned_legacy_blacklist_entries.add(b)
+            LOG.warning(
+                f"Session blacklisted_intents entry '{b}' uses the deprecated "
+                f"legacy '.intent'-suffixed id; support for this alias will "
+                f"be removed. Update mycroft.conf / session config to use the "
+                f"canonical id '{c}' instead.")
+    return frozenset(canonical)
+
+
 @lru_cache(maxsize=3)  # repeat calls under different conf levels wont re-run code
 def _calc_padatious_intent(utt: str,
                            intent_container: Union[IntentContainer, DomainIntentContainer],
@@ -931,8 +996,12 @@ def _calc_padatious_intent(utt: str,
     @return: matched PadatiousIntent
     """
     try:
+        blacklisted_intents = _canonicalize_blacklist(blacklisted_intents)
         # OVOS-INTENT-1 §2: match against the lowercase-normalized input so slot
         # values are case-insensitive, but report the original utterance as `sent`.
+        # Matches are canonical by construction (registration-time alias
+        # collapse, see PadatiousPipeline.register_intent), so only the
+        # blacklist needs canonicalizing here.
         matches = [m for m in intent_container.calc_intents(utt.lower())
                    if m.name not in blacklisted_intents
                    and m.name.split(":")[0] not in blacklisted_skills]

--- a/ovos_padatious/training_manager.py
+++ b/ovos_padatious/training_manager.py
@@ -72,6 +72,12 @@ class TrainingManager:
             reload_cache (bool): Whether to force reload of cache if it exists.
             must_train (bool): Whether training is required for the new intent/entity.
         """
+        # Re-registering an already-known name (e.g. the legacy and
+        # OVOS-INTENT-4 wire contracts both landing on the same canonical
+        # name, ovos-core#831) must replace the existing entry, not stack a
+        # duplicate matchable object alongside it.
+        self.remove(name)
+
         if not must_train:
             LOG.debug(f"Loading {name} from intent cache")
             self.objects.append(self.cls.from_file(name=name, folder=self.cache))

--- a/tests/test_ovoscope_e2e.py
+++ b/tests/test_ovoscope_e2e.py
@@ -152,5 +152,57 @@ class TestSessionBlacklist(_PadatiousHarness):
         self.expect_no_match("hello", session=sess, timeout=3.0)
 
 
+class TestSessionBlacklistAlias(_PadatiousHarness):
+    """ovos-workshop >= 9.3 dual-registers each ``.intent`` file under both
+    the legacy ``<skill_id>:<file>.intent`` id and the OVOS-INTENT-4
+    canonical ``<skill_id>:<file>`` id (ovos-core#831). The plugin collapses
+    that alias onto one canonical engine entry at REGISTRATION time (see
+    ``PadatiousPipeline.register_intent``/``handle_register_template``), so
+    a session blacklist entry naming either alias must suppress the single
+    canonical match, per OVOS-PIPELINE-1 §5.4. Here both messages go through
+    the legacy topic with different names to exercise the blacklist
+    canonicalization path directly; ``tests/test_registration_collapse.py``
+    covers the registration-time collapse across both wire topics.
+    """
+
+    LEGACY_NAME = f"{_PadatiousHarness.SKILL_ID}:hello.intent"
+    NEW_NAME = f"{_PadatiousHarness.SKILL_ID}:hello"
+
+    def _register_both_aliases(self):
+        self._register_intent(self.LEGACY_NAME, _HELLO_SAMPLES)
+        self._register_intent(self.NEW_NAME, _HELLO_SAMPLES)
+
+    def test_blacklisting_legacy_id_suppresses_new_alias(self):
+        self._register_both_aliases()
+        sess = make_session(
+            "bl-alias-legacy-test",
+            blacklisted_intents=[self.LEGACY_NAME],
+        )
+        self.expect_no_match("hello", session=sess, timeout=3.0)
+
+    def test_blacklisting_new_id_suppresses_legacy_alias(self):
+        self._register_both_aliases()
+        sess = make_session(
+            "bl-alias-new-test",
+            blacklisted_intents=[self.NEW_NAME],
+        )
+        self.expect_no_match("hello", session=sess, timeout=3.0)
+
+    def test_non_blacklisted_intent_still_matches(self):
+        self._register_both_aliases()
+        self._register_intent(f"{self.SKILL_ID}:bye", _BYE_SAMPLES)
+        sess = make_session(
+            "bl-alias-unrelated-test",
+            blacklisted_intents=[f"{self.SKILL_ID}:bye"],
+        )
+        msg = self.send_and_capture(
+            "hello",
+            expected_types=[self.LEGACY_NAME, self.NEW_NAME],
+            session=sess,
+            timeout=10.0,
+        )
+        self.assertIsNotNone(msg)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_registration_collapse.py
+++ b/tests/test_registration_collapse.py
@@ -1,0 +1,118 @@
+"""Registration-time alias collapse and blacklist canonicalization.
+
+ovos-workshop >= 9.3 dual-registers one logical intent under both the
+legacy ``<skill_id>:<file>.intent`` id (via ``padatious:register_intent``)
+and the OVOS-INTENT-4 canonical ``<skill_id>:<file>`` id (via
+``ovos.intent.register.template`` -> ``handle_register_template``). This
+plugin owns collapsing that alias at REGISTRATION time so both wire
+contracts land as a single engine entry (ovos-core#831).
+
+These tests cover:
+- both registration messages collapse to exactly one manifest entry
+- detaching by the legacy name removes the collapsed entry
+- the session blacklist filter still canonicalizes legacy-named entries
+  (since old sessions/config may carry them) and warns once per entry
+"""
+import unittest
+from unittest import mock
+
+from ovos_bus_client.message import Message
+from ovos_utils.messagebus import FakeBus
+
+from ovos_padatious.opm import PadatiousPipeline, _warned_legacy_blacklist_entries
+
+SKILL_ID = "collapse.skill"
+LEGACY_NAME = f"{SKILL_ID}:hello.intent"
+NEW_NAME = f"{SKILL_ID}:hello"
+LANG = "en-US"
+SAMPLES = ["hello", "hi there", "hey"]
+
+
+def legacy_register_msg():
+    return Message("padatious:register_intent", {
+        "skill_id": SKILL_ID, "name": LEGACY_NAME, "lang": LANG,
+        "samples": SAMPLES,
+    }, {"skill_id": SKILL_ID})
+
+
+def spec_register_msg():
+    return Message("ovos.intent.register.template", {
+        "skill_id": SKILL_ID, "intent_name": "hello", "lang": LANG,
+        "samples": SAMPLES,
+    }, {"skill_id": SKILL_ID})
+
+
+class TestRegistrationCollapse(unittest.TestCase):
+    def setUp(self):
+        self.pipeline = PadatiousPipeline(FakeBus())
+
+    def test_both_wire_contracts_collapse_to_one_manifest_entry(self):
+        self.pipeline.register_intent(legacy_register_msg())
+        self.pipeline.handle_register_template(spec_register_msg())
+
+        manifest = self.pipeline.registered_intents
+        self.assertEqual(manifest.count(NEW_NAME), 1)
+        self.assertNotIn(LEGACY_NAME, manifest)
+
+    def test_second_arrival_replaces_not_duplicates_engine_entry(self):
+        self.pipeline.register_intent(legacy_register_msg())
+        self.pipeline.handle_register_template(spec_register_msg())
+
+        container = self.pipeline.containers[LANG]
+        # engine-level object list must contain exactly one matchable entry
+        # for the canonical name, not two stacked duplicates
+        names = [i.name for i in
+                 container.intents.objects + container.intents.objects_to_train]
+        self.assertEqual(names.count(NEW_NAME), 1)
+
+    def test_detach_by_legacy_name_removes_collapsed_entry(self):
+        self.pipeline.register_intent(legacy_register_msg())
+        self.pipeline.handle_register_template(spec_register_msg())
+        self.assertIn(NEW_NAME, self.pipeline.registered_intents)
+
+        self.pipeline.handle_detach_intent(
+            Message("detach_intent", {"intent_name": LEGACY_NAME}))
+
+        self.assertNotIn(NEW_NAME, self.pipeline.registered_intents)
+
+
+class TestSessionBlacklistCanonicalization(unittest.TestCase):
+    """Matches are canonical by construction; only the blacklist entries
+    (which may still carry legacy-named sessions) need canonicalizing."""
+
+    def setUp(self):
+        _warned_legacy_blacklist_entries.clear()
+        self.pipeline = PadatiousPipeline(FakeBus())
+        self.pipeline.register_intent(legacy_register_msg())
+        self.pipeline.handle_register_template(spec_register_msg())
+        self.pipeline.train()
+
+    def test_legacy_named_blacklist_entry_suppresses_canonical_match(self):
+        sess = mock.Mock()
+        sess.blacklisted_intents = [LEGACY_NAME]
+        sess.blacklisted_skills = []
+        sess.intent_context = {}
+        with mock.patch("ovos_padatious.opm.SessionManager.get", return_value=sess):
+            intent = self.pipeline.calc_intent("hello", lang=LANG)
+        self.assertIsNone(intent)
+
+    def test_legacy_named_blacklist_entry_logs_deprecation_warning_once(self):
+        sess = mock.Mock()
+        sess.blacklisted_intents = [LEGACY_NAME]
+        sess.blacklisted_skills = []
+        sess.intent_context = {}
+        from ovos_padatious.opm import _calc_padatious_intent
+        _calc_padatious_intent.cache_clear()
+        with mock.patch("ovos_padatious.opm.SessionManager.get", return_value=sess), \
+                mock.patch("ovos_padatious.opm.LOG.warning") as mock_warn:
+            self.pipeline.calc_intent("hello", lang=LANG)
+            self.pipeline.calc_intent("hi there", lang=LANG)
+
+        deprecation_calls = [c for c in mock_warn.call_args_list
+                             if LEGACY_NAME in str(c)]
+        self.assertEqual(len(deprecation_calls), 1)
+        self.assertIn(NEW_NAME, str(deprecation_calls[0]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Root cause

`ovos-workshop` >= 9.3.1a2 dual-emits one skill capability under two wire
forms while it migrates to OVOS-INTENT-4: the legacy
`padatious:register_intent` contract (`name = <skill_id>:<file>.intent`)
and the spec `ovos.intent.register.template` contract (`intent_name` has
the `.intent` suffix already stripped by `_clean_padatious_name`). This
plugin listens to both topics, so a single skill `.intent` file lands in
the padatious container as two independently matchable names for what
is, to a session author, one logical intent.

`OVOS-PIPELINE-1 §5.4` defines `session.blacklisted_intents` as an array
of fully-qualified `<skill_id>:<intent_name>` strings compared against
the candidate match's identity. Blacklisting one alias left the *other*
alias free to match, letting a session-blacklisted intent still fire —
the bypass reported in OpenVoiceOS/ovos-core#831.

I did not touch the dual-registration itself: it is an intentional,
already-documented transitional measure in ovos-workshop that lets
either an old-style or a spec-conformant padatious consumer pick up the
same skill definition during the INTENT-4 migration window.

## Design: collapse the alias at registration time, not compare time

An earlier version of this PR fixed the bypass by dealiasing both sides
of the blacklist comparison at match time. That papered over the
symptom but left the real defect in place: **the container still
indexes two matchable engine entries for one logical intent** — a
detach by one alias didn't remove the other, and every match ran
against two candidates instead of one.

This plugin is the one that dual-subscribes to both wire topics, so it
is the one that owns collapsing the alias. The fix now does that at
**registration time**:

- `register_intent` (legacy topic handler) and `handle_register_template`
  (spec topic handler) both canonicalize the intent name — strip a
  trailing `.intent` suffix — before indexing/training, so both wire
  messages land as a **single** engine entry regardless of arrival order.
- `__detach_intent` canonicalizes too, so detaching by either the legacy
  or the canonical alias works.
- Made re-registration of the same canonical name idempotent at the
  engine level: `training_manager.IntentManager.add()` previously
  *appended* a new trainable object on every call, so the second arrival
  (the second wire topic firing for the same logical intent) was
  stacking a duplicate matchable entry rather than replacing the first.
  It now removes any existing object under that name first. Container
  `blacklisted_words` bookkeeping was switched from accumulating (`+=`)
  to replacing (`=`) for the same reason.
- The blacklist filter (`_calc_padatious_intent`) no longer dealiases
  `Match.name` — engine matches are canonical by construction now, since
  registration collapsed the alias before training. It still
  canonicalizes the **blacklist entries themselves**, since an existing
  session or `mycroft.conf` may still list an intent by its legacy
  `.intent`-suffixed id. A one-time-per-entry `LOG.warning` flags any
  such legacy blacklist entry as deprecated, naming the offending entry
  and its canonical replacement, so operators know to update their
  config. Registration-time collapse of the dual-emit topics itself
  stays silent — that's plugin-internal back-compat, not user config.

## Tests

- `tests/test_ovoscope_e2e.py::TestSessionBlacklistAlias` — kept, updated
  docstring: blacklisting either alias suppresses the match; unrelated
  intents unaffected.
- New `tests/test_registration_collapse.py`:
  - `TestRegistrationCollapse` — both wire messages for the same logical
    intent collapse to exactly one manifest entry and one engine object;
    detaching by the legacy name removes the collapsed entry.
  - `TestSessionBlacklistCanonicalization` — a legacy-named blacklist
    entry still suppresses the (now-canonical) match, and logs the
    deprecation warning exactly once regardless of how many utterances
    are matched against it.

Full suite: 111 passed (4 pre-existing, unrelated `test_context_gating.py`
failures — reproduced identically on `dev`, not touched by this PR).

## End-to-end verification — and a gap it surfaced

Installed this branch over the alpha stack in `~/.venvs/core-alpha-bump`
and ran ovos-core's own end-to-end suite:

```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest test/end2end/test_padatious.py -v
```

`test_intent_blacklist` and `test_skill_blacklist` are green — the
regression this PR targets is fixed.

However, `test_padatious_match` (a real hello-world-skill dispatch
round-trip, both bus namespaces) now fails. Root cause: ovos-workshop's
`OVOSSkill.register_intent_file()` binds the skill's dispatch handler
**only** to the legacy `<skill_id>:<file>.intent` topic
(`self.add_event(name, handler, ...)` where `name` includes the
suffix) — it does not also bind to the spec canonical topic. ovos-core's
`IntentService._dispatch_match` dispatches on `match.match_type`
verbatim (`message.reply(match.match_type, data)`). Since this plugin's
matched intent name is now the canonicalized (suffix-stripped) name,
the dispatch message no longer reaches the handler ovos-workshop
registered.

This is **not fixable in this plugin** — it's a dispatch-binding gap in
ovos-workshop (or a routing gap in ovos-core, e.g. dispatching on both
the canonical name and its legacy alias). Flagging it here since it's a
direct, real consequence of collapsing the alias at registration time;
it did not show up with the earlier compare-time-only fix because that
version left the legacy-suffixed engine entry in place for dispatch to
target.

Cross-reference: OpenVoiceOS/ovos-core#831

🤖 Generated with [Claude Code](https://claude.com/claude-code)
