### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,29 @@
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE.md) 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE.md)
+
 # Padatious
 
-An efficient and agile neural network intent parser, implemented in pure numpy with a [FANN](https://github.com/libfann/fann)-compatible model format.
-
-This repository contains a OVOS pipeline plugin and bundles a fork of the original [padatious](https://github.com/MycroftAI/padatious) from the defunct MycroftAI
+Padatious is a neural network intent parser, implemented in pure numpy with a [FANN](https://github.com/libfann/fann)-compatible model format. This repository packages it as an [OpenVoiceOS](https://openvoiceos.org/) (OVOS) pipeline plugin and bundles a maintained fork of the original [padatious](https://github.com/MycroftAI/padatious) from Mycroft AI.
 
 ## Features
 
- - Intents are easy to create
- - Requires a relatively small amount of data
- - Intents run independent of each other
- - Easily extract entities (ie. Find the nearest *gas station* -> `place: gas station`)
- - Fast training with a modular approach to neural networks
+- Intents are easy to create from a handful of example sentences.
+- Each intent trains its own small network, independent of the others.
+- Fast training on a small amount of data.
+- Entity extraction from a matched sentence (for example, `Find the nearest {place}` matches "Find the nearest gas station" and extracts `place: gas station`).
 
+## Installing
 
-### Installing
+Padatious is pure Python (numpy). It needs no native libraries or compilers.
 
-Padatious is pure Python — no native packages or compilers required.
+Install from PyPI:
 
-Install via `pip3`:
-
+```bash
+pip install ovos-padatious-pipeline-plugin
 ```
-pip3 install padatious
-```
-Padatious also works in Python 2 if you are unable to upgrade.
 
-### Direct Usage
+## Direct Usage
 
-Here's a simple example of how to use Padatious:
-
-```Python
+```python
 from ovos_padatious import IntentContainer
 
 container = IntentContainer('intent_cache')
@@ -44,6 +38,14 @@ print(container.calc_intent('Search for cats on CatTube.'))
 container.remove_intent('goodbye')
 ```
 
-### License
+Inside OVOS, the plugin is discovered automatically through its `opm.pipeline` entry point. See [docs/](docs/README.md) for installation details, the intent file syntax, the full Python API, pipeline configuration, and the matching algorithm.
 
-Licensed under the Apache 2 license.
+## Related projects
+
+- [OpenVoiceOS/ovos-spec-tools](https://github.com/OpenVoiceOS/ovos-spec-tools): the reference implementation of the OVOS architecture specifications, used here for sentence-template expansion and language tag handling.
+- [OpenVoiceOS/architecture](https://github.com/OpenVoiceOS/architecture): the OpenVoiceOS architecture specifications.
+- [OpenVoiceOS/ovos-plugin-manager](https://github.com/OpenVoiceOS/ovos-plugin-manager): the plugin and entry-point system that loads this pipeline into OVOS.
+
+## License
+
+Licensed under the Apache 2.0 license.

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -276,4 +276,7 @@ print(result.get('engine', 'google'))  # 'CatTube'
 result.detokenize()
 ```
 
-Converts `sent` and `matches` from token lists back to human-readable strings, handling apostrophes correctly. Called automatically by the OVOS pipeline; typically not needed in direct usage.
+Converts `sent` and `matches` from token lists back to human-readable strings, handling apostrophes correctly. The OVOS pipeline calls this automatically. Direct usage typically does not need it.
+
+---
+[← Intent Format](intent_format.md) · [Home](README.md) · [OVOS Pipeline →](ovos_pipeline.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,8 +4,8 @@
 
 The plugin is composed of two loosely-coupled layers:
 
-1. **Core engine** (`ovos_padatious/`) — a pure-Python intent matching library that can be used standalone.
-2. **OVOS plugin** (`ovos_padatious/opm.py`) — wraps the core engine as an OVOS pipeline plugin.
+1. **Core engine** (`ovos_padatious/`): a pure-Python intent matching library that can be used standalone.
+2. **OVOS plugin** (`ovos_padatious/opm.py`): wraps the core engine as an OVOS pipeline plugin.
 
 ```
  User utterance
@@ -33,7 +33,7 @@ The top-level API class. It:
 
 - Holds an `IntentManager` and an `EntityManager`.
 - Optionally holds a `padaos.IntentContainer` for fast exact matching.
-- Tracks a `must_train` flag. Calling any `add_*` / `load_*` / `remove_*` method sets it; calling `train()` clears it.
+- Tracks a `must_train` flag. Calling any `add_*` / `load_*` / `remove_*` method sets it. Calling `train()` clears it.
 - Serializes all registration calls in `serialized_args` so the container can be replicated via `get_training_args` / `apply_training_args`.
 
 ### `DomainIntentContainer` (`domain_container.py`)
@@ -56,7 +56,7 @@ A lightweight, regex-based exact matcher that runs **before** the neural network
 - Deterministic, predictable results for common utterances.
 - Optional disabling via `disable_padaos=True`.
 
-Regex compilation is protected by a `threading.Lock` for thread safety.
+A `threading.Lock` protects regex compilation for thread safety.
 
 ### `IntentManager` / `EntityManager` (`intent_manager.py`, `entity_manager.py`)
 
@@ -101,8 +101,8 @@ Maps tokens to fixed indices for the neural network input vector. Backed by a pe
 
 ### `util.py`
 
-- `tokenize(sent)` — lowercases and splits on whitespace/punctuation boundaries.
-- `resolve_conflicts(inputs, outputs)` — handles cases where the same input vector maps to conflicting target outputs during training.
+- `tokenize(sent)`: lowercases the input and splits it on whitespace and punctuation boundaries.
+- `resolve_conflicts(inputs, outputs)`: handles cases where the same input vector maps to conflicting target outputs during training.
 
 ## Threading Model
 
@@ -126,3 +126,6 @@ Maps tokens to fixed indices for the neural network input vector. Backed by a pe
 ```
 
 The hash files allow `instantiate_from_disk()` to skip re-training unchanged intents on startup.
+
+---
+[← OVOS Pipeline](ovos_pipeline.md) · [Home](README.md) · [Theory →](theory.md)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-Padatious is pure Python (numpy) — no native libraries or compilers are required.
+Padatious is pure Python (numpy). It needs no native libraries or compilers.
 
 ## Python Package
 
@@ -38,3 +38,6 @@ print(container.calc_intent('hello world'))
 ```
 
 If no exceptions are raised and a `MatchData` object is printed, the installation is working correctly.
+
+---
+[Home](README.md) · [Intent Format →](intent_format.md)

--- a/docs/intent_format.md
+++ b/docs/intent_format.md
@@ -52,7 +52,7 @@ set a {duration} (timer|alarm)
 | Token | Meaning |
 |---|---|
 | `#` | Matches any digit (`\d`) |
-| `:0` | Wildcard — matches one or more words |
+| `:0` | Wildcard, matches one or more words |
 
 ```
 call extension ##      # matches "call extension 42"
@@ -124,4 +124,7 @@ The intent will not fire if the word `"video"` appears anywhere in the utterance
 - More varied training samples generally improve accuracy.
 - Keep entity files focused — only include realistic values.
 - Use alternatives to cover common phrasings rather than writing each one separately.
-- Intents are independent; the engine scores all of them and returns the best match.
+- Intents are independent. The engine scores all of them and returns the best match.
+
+---
+[← Installation](installation.md) · [Home](README.md) · [API Reference →](api_reference.md)

--- a/docs/ovos_pipeline.md
+++ b/docs/ovos_pipeline.md
@@ -109,12 +109,15 @@ Utterances for unsupported languages are passed through without stemming.
 
 The OVOS pipeline calls matchers at three confidence levels in sequence:
 
-1. `match_high` (≥ `conf_high`, default 0.95) — very confident matches
-2. `match_medium` (≥ `conf_med`, default 0.8) — good matches
-3. `match_low` (≥ `conf_low`, default 0.5) — lower-confidence fallback
+1. `match_high` (≥ `conf_high`, default 0.95): very confident matches
+2. `match_medium` (≥ `conf_med`, default 0.8): good matches
+3. `match_low` (≥ `conf_low`, default 0.5): lower-confidence fallback
 
 Exact regex matches from the padaos layer always receive a confidence of `1.0` and will therefore always satisfy `match_high`.
 
 ## Word Limit
 
 Utterances longer than **50 words** are silently skipped to avoid excessive computation. This limit is not configurable.
+
+---
+[← API Reference](api_reference.md) · [Home](README.md) · [Architecture →](architecture.md)

--- a/docs/theory.md
+++ b/docs/theory.md
@@ -2,7 +2,7 @@
 
 ## Design Philosophy
 
-Padatious was designed around a specific constraint: a voice assistant skill developer should be able to define intents with a small number of example sentences and get reliable matching without tuning hyperparameters or understanding machine learning.
+Padatious was designed around a specific constraint. A voice assistant skill developer should be able to define intents with a small number of example sentences. Matching should be reliable without tuning hyperparameters or understanding machine learning.
 
 Two guiding principles follow from this:
 
@@ -16,7 +16,7 @@ Two guiding principles follow from this:
 
 Every query passes through two independent matchers. Their results are merged before the best intent is selected.
 
-### Layer 1 — padaos (regex exact match)
+### Layer 1: padaos (regex exact match)
 
 Before any neural network is consulted, the intent template syntax is compiled into regular expressions. This happens once at train time and is stored in memory.
 
@@ -30,19 +30,19 @@ The regex compiler (`padaos.py`) transforms template lines through a chain of su
 
 When a query fully matches a regex, the intent is returned with confidence `1.0` and extracted entities taken directly from the named capture groups. No neural network runs for that query.
 
-This layer is fast and deterministic. Its limitation is that it only fires on exact structural matches — minor rephrasing, extra words, or typos cause it to miss.
+This layer is fast and deterministic. Its limitation is that it only fires on exact structural matches. Minor rephrasing, extra words, or typos cause it to miss.
 
-### Layer 2 — FANN neural networks (fuzzy match)
+### Layer 2: FANN neural networks (fuzzy match)
 
 For queries that don't produce an exact regex match (or when padaos is disabled), every registered intent's neural network is scored. The best-scoring intent above the confidence threshold wins.
 
-The two layers are complementary: padaos catches the common exact cases with zero inference cost; FANN handles paraphrase and partial matches.
+The two layers are complementary. Padaos catches the common exact cases with zero inference cost. FANN handles paraphrase and partial matches.
 
 ---
 
 ## Feature Engineering (Vectorization)
 
-Each intent's neural network operates on a bag-of-tokens feature vector. The vocabulary is determined at training time from the intent's own sample sentences — tokens that never appeared in training are not given dedicated indices.
+Each intent's neural network operates on a bag-of-tokens feature vector. The vocabulary is determined at training time from the intent's own sample sentences. Tokens that never appeared in training get no dedicated index.
 
 For a given input sentence, the vector is constructed as follows:
 
@@ -64,7 +64,7 @@ Each intent gets one FANN feed-forward network with the architecture:
 [vocab_size]  →  [10]  →  [1]
 ```
 
-The hidden layer uses `SIGMOID_SYMMETRIC_STEPWISE` (maps to `[-1, 1]`); the output uses the same. The output is clamped to `[0, 1]` by `max(0, raw_output)`. A score near `1.0` means "this sentence matches this intent"; near `0.0` means it does not.
+The hidden layer uses `SIGMOID_SYMMETRIC_STEPWISE` (maps to `[-1, 1]`), and the output layer uses the same function. The output is clamped to `[0, 1]` by `max(0, raw_output)`. A score near `1.0` means "this sentence matches this intent". A score near `0.0` means it does not.
 
 ### Training data augmentation
 
@@ -124,7 +124,7 @@ Three signals are combined for each candidate extraction:
 
 The geometric mean (via `sqrt(a × b)`) ensures both signals must be positive for the extraction to help. A strong position but a poor entity value (or vice versa) yields a smaller bonus than both being strong.
 
-The final `MatchData` for each candidate is ranked by total confidence. The pipeline returns the best-confidence result with the **fewest total characters** in its extractions — preferring tight, precise matches over sprawling ones.
+The final `MatchData` for each candidate is ranked by total confidence. The pipeline returns the best-confidence result with the **fewest total characters** in its extractions, preferring tight, precise matches over sprawling ones.
 
 ### Edge training augmentation
 
@@ -134,13 +134,13 @@ Edge networks also receive pollution: for each positive boundary position, addit
 
 ## Domain Classification (`DomainIntentContainer`)
 
-When many intents from many skills are registered, the full pairwise scoring can become noisy — an intent from an unrelated skill may produce a spuriously high score simply because the vocabulary overlaps.
+When many intents from many skills are registered, the full pairwise scoring can become noisy. An intent from an unrelated skill may produce a spuriously high score simply because the vocabulary overlaps.
 
 The domain engine addresses this with a two-pass strategy:
 
-**Pass 1 — domain selection.** A top-level `IntentContainer` is trained on the union of all samples per domain (one sample set per skill). This network classifies "what domain does this query belong to?" and returns the top-k scoring domains.
+**Pass 1: domain selection.** A top-level `IntentContainer` is trained on the union of all samples per domain (one sample set per skill). This network classifies "what domain does this query belong to?" and returns the top-k scoring domains.
 
-**Pass 2 — intent matching.** Only the per-domain containers for the selected domains are scored. These containers have much smaller vocabularies and fewer intents, reducing cross-skill interference.
+**Pass 2: intent matching.** Only the per-domain containers for the selected domains are scored. These containers have much smaller vocabularies and fewer intents, reducing cross-skill interference.
 
 The trade-off is an extra training step and a slightly longer inference path. The benefit is better isolation between unrelated skills.
 
@@ -154,7 +154,7 @@ When an intent is added or loaded, the sorted training lines are hashed with `xx
 
 At startup, `instantiate_from_disk` reads the cache directory and reconstructs all intents whose `.hash`, `.net`, and `.ids` files are present. When `train()` is called, only intents whose training data hash has changed since the last run are actually re-trained.
 
-This means a typical restart after adding one new skill only trains the new skill's intents; all other networks are loaded directly from disk.
+This means a typical restart after adding one new skill only trains the new skill's intents. All other networks load directly from disk.
 
 ---
 
@@ -169,15 +169,15 @@ The choice to give each intent its own tiny network rather than using a single s
 - **No catastrophic forgetting.** Adding a new intent never touches existing network weights.
 - **The vocabulary is minimal.** Each network only allocates features for tokens it has actually seen, so even 200 intents do not collectively produce a huge feature space.
 
-The cost is that each network makes its decision in isolation — there is no global context shared across intents.
+The cost is that each network makes its decision in isolation. There is no global context shared across intents.
 
 ### Tiny dense networks over modern frameworks
 
-The networks are small enough (tens to hundreds of weights) that a plain numpy implementation (`ovos_padatious.fann`) trains them in milliseconds and runs inference with negligible overhead — no GPU, no native libraries, and models load in microseconds. This matters for a voice assistant where the full intent pipeline must complete in tens of milliseconds. The on-disk model format remains FANN_FLO_2.1, so models trained by historic libfann-based releases keep loading unchanged.
+The networks are small enough, tens to hundreds of weights, that a plain numpy implementation (`ovos_padatious.fann`) trains them in milliseconds. Inference runs with negligible overhead: no GPU, no native libraries, and models load in microseconds. This matters for a voice assistant, where the full intent pipeline must complete in tens of milliseconds. The on-disk model format remains FANN_FLO_2.1, so models trained by historic libfann-based releases keep loading unchanged.
 
 ### Bag-of-words feature representation
 
-Ignoring word order makes the vectorization simple and fast, and means the network is robust to paraphrasing within the same vocabulary. It also means the network cannot distinguish "dog bites man" from "man bites dog". In practice, for the short, constrained utterances typical of voice commands, word order ambiguity is rare.
+Ignoring word order keeps the vectorization simple and fast, and lets the network tolerate paraphrasing within the same vocabulary. It also means the network cannot distinguish "dog bites man" from "man bites dog". In practice, for the short, constrained utterances typical of voice commands, word order ambiguity is rare.
 
 ### Contrastive negative sampling
 
@@ -193,10 +193,13 @@ Rather than using a softmax over all intents, each binary network is trained wit
 
 **Training data size.** Contrastive training works well when all intents have comparable sample counts. A very large intent can dominate the negative sample pool and make it harder for small intents to learn.
 
-**Fixed network topology.** Every `SimpleIntent` uses a `[vocab, 10, 1]` network regardless of intent complexity. A very simple intent wastes capacity; a complex one may underfit. There is no automatic capacity tuning.
+**Fixed network topology.** Every `SimpleIntent` uses a `[vocab, 10, 1]` network regardless of intent complexity. A very simple intent wastes capacity. A complex one may underfit. There is no automatic capacity tuning.
 
 **Tokenization is language-agnostic.** The tokenizer splits on character-class boundaries (alpha / digit / punctuation). This works for space-separated European languages but is unsuitable for logographic scripts (Chinese, Japanese, Korean) or languages where morphology is encoded by affixes rather than separate tokens (Finnish, Turkish). The optional Snowball stemmer helps somewhat for inflected languages but does not address tokenization.
 
 **Entity extraction is O(N²).** For each slot, every pair of positions in the sentence is evaluated by the edge networks. Long sentences are thus quadratically expensive in entity extraction, which is why utterances exceeding 50 words are rejected entirely.
 
 **Regex exact matching requires exact templates.** The padaos layer only fires when the query matches the template structure precisely. It provides no tolerance for punctuation variation, extra articles, or different word forms not explicitly listed as alternatives.
+
+---
+[← Architecture](architecture.md) · [Home](README.md)


### PR DESCRIPTION
Rewrites the README and all `docs/*.md` pages in Simplified Technical English for clarity. Fixes the stale install instructions in the README (wrong package name, false Python 2 claim) and adds a related-projects section. Adds the standard footer navigation across the multi-page docs set.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed the project overview, features, examples, installation guidance, package details, and license information.
  * Clarified API usage, pipeline behavior, intent matching, confidence tiers, architecture, and system limitations.
  * Added navigation links and related-project references throughout the documentation.
  * Improved formatting, wording, and consistency across documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->