### PR TITLE
fix: collapse munged entity names so file-registered slots actually constrain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ __pycache__/
 coverage.xml
 /.project
 /.pydevproject
+temp/

--- a/ovos_padatious/entity_manager.py
+++ b/ovos_padatious/entity_manager.py
@@ -56,9 +56,18 @@ class EntityManager(TrainingManager):
         Removes an entity from the manager.
 
         Args:
-            name (str): The name of the entity to remove.
+            name (str): The name of the entity to remove. Accepted either
+                bare (``<skill_id>:<entity>`` / ``<entity>``) or already
+                wrapped (``<skill_id>:{<entity>}`` / ``{<entity>}``).
         """
-        name = '{' + name + '}'
+        # entities are stored under Entity.wrap_name(), i.e.
+        # ``<skill_id>:{<entity>}`` - the brace goes around the entity token
+        # only, NOT around the whole namespaced name. Wrapping blindly here
+        # produced ``{<skill_id>:<entity>}``, which matched nothing, so no
+        # entity was ever removable and TrainingManager.add's replace-on-
+        # re-register stacked duplicate objects instead of collapsing them.
+        if '{' not in name:
+            name = Entity.wrap_name(name)
         if name in self.entity_dict:
             del self.entity_dict[name]
         super(EntityManager, self).remove(name)

--- a/ovos_padatious/opm.py
+++ b/ovos_padatious/opm.py
@@ -568,7 +568,21 @@ class PadatiousPipeline(ConfidenceMatcherPipeline):
         """
         lang = message.data.get('lang', self.lang)
         lang = standardize_lang(lang)
+        # ovos-workshop's register_entity_file() munges the entity name with a
+        # trailing ``_<md5>``; match-time slot lookup uses the raw slot token,
+        # so an un-collapsed name yields an unconstrained wildcard slot. Fold
+        # it here, at registration time - this plugin owns its lookup contract
+        # and this repairs every emitter vintage at once.
+        message.data['name'] = _dealias_entity_name(message.data['name'])
+
         if lang in self.containers:
+            # a dual-emitting emitter (>= 9.3) sends the same entity twice,
+            # once per wire contract; both collapse to one canonical name, so
+            # the manifest must hold exactly one entry for it
+            self.registered_entities = [
+                e for e in self.registered_entities
+                if e.get("name") != message.data['name']
+                or standardize_lang(e.get("lang") or self.lang) != lang]
             self.registered_entities.append(message.data)
             lang, skill_id, name, samples, _ = self._unpack_object(message)
             LOG.debug('Registering Padatious entity: ' + message.data['name'])
@@ -951,6 +965,37 @@ def _dealias_intent_name(name: Optional[str]) -> Optional[str]:
     if name and name.endswith(".intent"):
         return name[:-len(".intent")]
     return name
+
+
+# ovos-workshop's ``register_entity_file`` builds the entity name as
+# ``<skill_id>:<basename>_<md5(entity_file)>``. That hash is emitter-internal
+# bookkeeping, never part of the wire contract: the ``<skill_id>:`` prefix
+# already namespaces the entity, and the hash is taken over the file name that
+# is already in the key, so it adds no disambiguation at all.
+_ENTITY_HASH_SUFFIX = re.compile(r"_[0-9a-f]{32}$")
+
+
+def _dealias_entity_name(name: Optional[str]) -> Optional[str]:
+    """Fold the legacy munged entity id onto the canonical
+    ``<skill_id>:<entity>`` id.
+
+    Slot lookup (:meth:`ovos_padatious.entity_manager.EntityManager.find`)
+    builds its candidate key from the matching intent's skill_id plus the RAW
+    slot token written in the template, so a hash-suffixed (or ``.entity``
+    suffixed) registration can never be found and the slot degrades to an
+    unconstrained wildcard.
+
+    Collapsing at REGISTRATION time - where this plugin owns its own lookup
+    contract - repairs every emitter vintage, including deployed ovos-workshop
+    releases that will keep emitting the munged name. It also makes the legacy
+    twin of an ovos-workshop >= 9.3 dual-emit land on the same canonical name
+    as its OVOS-INTENT-4 ``ovos.entity.register`` twin.
+    """
+    if not name:
+        return name
+    if name.endswith(".entity"):
+        name = name[:-len(".entity")]
+    return _ENTITY_HASH_SUFFIX.sub("", name)
 
 
 # Legacy `.intent`-suffixed blacklist entries are deprecated compat, not a

--- a/tests/test_entity_name_collapse.py
+++ b/tests/test_entity_name_collapse.py
@@ -1,0 +1,188 @@
+"""Entity-name collapse on the legacy ``padatious:register_entity`` contract.
+
+ovos-workshop's ``register_entity_file`` names the entity
+``<skill_id>:<basename>_<md5(entity_file)>`` and puts that munged name on the
+legacy ``padatious:register_entity`` topic verbatim. Slot lookup
+(``EntityManager.find``) builds the candidate key from the intent's skill_id
+plus the RAW slot token from the template, so it can never find the
+hash-suffixed entry: every file-registered entity ended up as an
+unconstrained wildcard slot.
+
+This plugin owns its lookup contract, so it collapses the munged name at
+REGISTRATION time — which fixes every emitter vintage, including the old
+workshop releases that will keep emitting the munged name forever.
+"""
+import unittest
+
+from ovos_bus_client.message import Message
+from ovos_utils.messagebus import FakeBus
+
+from ovos_padatious.opm import PadatiousPipeline
+
+SKILL_ID = "entity.collapse.skill"
+LANG = "en-US"
+# the exact name ovos-workshop's register_entity_file() builds for
+# "weekend.entity": md5("weekend") == 4ca4f434da0ea97ebff27833d69728d3
+ENTITY_FILE = "weekend"
+MUNGED_NAME = f"{SKILL_ID}:weekend_4ca4f434da0ea97ebff27833d69728d3"
+CLEAN_NAME = f"{SKILL_ID}:weekend"
+INTENT_NAME = f"{SKILL_ID}:ask.day"
+
+ENTITY_SAMPLES = ["saturday", "sunday"]
+INTENT_SAMPLES = ["is it {weekend}"]
+
+
+def _wrapped(name):
+    """Engine-side name: ``<skill_id>:{<entity>}`` (Entity.wrap_name)."""
+    skill_id, ent = name.split(":", 1)
+    return f"{skill_id}:{{{ent}}}"
+
+
+def _md5_check():
+    from hashlib import md5
+    return md5(ENTITY_FILE.encode("utf-8")).hexdigest()
+
+
+class TestLegacyEntityNameCollapse(unittest.TestCase):
+    """Red -> green: the REAL munged legacy payload must constrain the slot."""
+
+    def setUp(self):
+        self.pipeline = PadatiousPipeline(
+            FakeBus(), config={"instant_train": True})
+
+    def tearDown(self):
+        self.pipeline.shutdown()
+
+    def test_fixture_matches_workshop_naming(self):
+        # guards the fixture: if workshop's hash input ever changes, this
+        # test tells you the payload under test is no longer the real one
+        self.assertEqual(MUNGED_NAME,
+                         f"{SKILL_ID}:{ENTITY_FILE}_{_md5_check()}")
+
+    def _register(self):
+        self.pipeline.register_entity(Message(
+            "padatious:register_entity",
+            {"skill_id": SKILL_ID, "name": MUNGED_NAME, "lang": LANG,
+             "samples": ENTITY_SAMPLES},
+            {"skill_id": SKILL_ID}))
+        self.pipeline.register_intent(Message(
+            "padatious:register_intent",
+            {"skill_id": SKILL_ID, "name": INTENT_NAME, "lang": LANG,
+             "samples": INTENT_SAMPLES},
+            {"skill_id": SKILL_ID}))
+        self.pipeline.train(Message("mycroft.skills.train"))
+
+    def test_munged_legacy_entity_constrains_the_slot(self):
+        self._register()
+        container = self.pipeline.containers[LANG]
+
+        good = container.calc_intent("is it saturday")
+        self.assertEqual(good.name, INTENT_NAME)
+        self.assertEqual(good.matches.get("weekend"), "saturday")
+
+        # out-of-entity value must NOT fill the slot with high confidence
+        bad = container.calc_intent("is it pizza")
+        self.assertLess(bad.conf, good.conf)
+
+    def test_entity_is_registered_under_the_clean_name(self):
+        self._register()
+        container = self.pipeline.containers[LANG]
+        names = [e.name for e in container.entities.objects
+                 + container.entities.objects_to_train]
+        self.assertIn(_wrapped(CLEAN_NAME), names)
+        self.assertNotIn(_wrapped(MUNGED_NAME), names)
+
+
+class TestEntityRegistrationExactlyOnce(unittest.TestCase):
+    """F3: workshop >= 9.3 dual-emits one entity (munged legacy twin + clean
+    spec twin). Once both collapse to the same name, registration must stay
+    idempotent — one manifest entry, one engine object.
+    """
+
+    def setUp(self):
+        self.pipeline = PadatiousPipeline(FakeBus())
+
+    def tearDown(self):
+        self.pipeline.shutdown()
+
+    def _dual_register(self):
+        self.pipeline.register_entity(Message(
+            "padatious:register_entity",
+            {"skill_id": SKILL_ID, "name": MUNGED_NAME, "lang": LANG,
+             "samples": ENTITY_SAMPLES},
+            {"skill_id": SKILL_ID}))
+        self.pipeline.handle_register_entity_spec(Message(
+            "ovos.entity.register",
+            {"skill_id": SKILL_ID, "entity_name": ENTITY_FILE, "lang": LANG,
+             "samples": ENTITY_SAMPLES},
+            {"skill_id": SKILL_ID}))
+
+    def test_manifest_has_exactly_one_entry(self):
+        self._dual_register()
+        names = [e.get("name") for e in self.pipeline.registered_entities]
+        self.assertEqual(names.count(CLEAN_NAME), 1)
+        self.assertNotIn(MUNGED_NAME, names)
+
+    def test_engine_has_exactly_one_object(self):
+        self._dual_register()
+        container = self.pipeline.containers[LANG]
+        names = [e.name for e in container.entities.objects
+                 + container.entities.objects_to_train]
+        self.assertEqual(names.count(_wrapped(CLEAN_NAME)), 1)
+
+    def test_spec_deregister_removes_the_legacy_twin(self):
+        self._dual_register()
+        self.pipeline.handle_deregister_entity_spec(Message(
+            "ovos.entity.deregister",
+            {"skill_id": SKILL_ID, "entity_name": ENTITY_FILE},
+            {"skill_id": SKILL_ID}))
+        names = [e.get("name") for e in self.pipeline.registered_entities]
+        self.assertNotIn(CLEAN_NAME, names)
+
+
+class TestEntityRemoval(unittest.TestCase):
+    """Entities are stored as ``<skill_id>:{<entity>}``; removal must build
+    the same key. Wrapping the whole namespaced name instead matched nothing,
+    so entities were unremovable and re-registration stacked duplicates.
+    """
+
+    def setUp(self):
+        self.pipeline = PadatiousPipeline(FakeBus())
+
+    def tearDown(self):
+        self.pipeline.shutdown()
+
+    @staticmethod
+    def _engine_names(container):
+        return [e.name for e in container.entities.objects
+                + container.entities.objects_to_train]
+
+    def test_namespaced_entity_is_actually_removed_from_the_engine(self):
+        container = self.pipeline.containers[LANG]
+        container.add_entity(CLEAN_NAME, ENTITY_SAMPLES)
+        self.assertIn(_wrapped(CLEAN_NAME), self._engine_names(container))
+
+        container.remove_entity(CLEAN_NAME)
+
+        self.assertNotIn(_wrapped(CLEAN_NAME), self._engine_names(container))
+
+    def test_global_entity_removal_still_works(self):
+        container = self.pipeline.containers[LANG]
+        container.add_entity("weekday", ["monday", "tuesday"])
+        self.assertIn("{weekday}", self._engine_names(container))
+
+        container.remove_entity("weekday")
+
+        self.assertNotIn("{weekday}", self._engine_names(container))
+
+    def test_reregistering_an_entity_does_not_stack_duplicates(self):
+        container = self.pipeline.containers[LANG]
+        container.add_entity(CLEAN_NAME, ENTITY_SAMPLES)
+        container.add_entity(CLEAN_NAME, ENTITY_SAMPLES + ["friday"])
+        names = [e.name for e in container.entities.objects
+                 + container.entities.objects_to_train]
+        self.assertEqual(names.count(_wrapped(CLEAN_NAME)), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

## The bug

`ovos-workshop`'s `register_entity_file()` names an entity
`<skill_id>:<basename>_<md5(entity_file)>` and puts that name on
`padatious:register_entity` verbatim.

Slot lookup never sees that name. `EntityManager.find` builds its candidate key
from the matching intent's `skill_id` plus the **raw slot token** written in the
template (`intent_name.split(':')[0] + ':' + token`), with a bare-token global
fallback. A hash-suffixed registration matches neither, so the slot falls back to
an unconstrained wildcard.

`_dealias_intent_name` only folds a trailing `.intent` and was never applied on
the entity path. Net effect: **every skill that uses entity files got wildcard
slots**. Found live in `ggwave` and `pokepedia`.

## The fix

Collapse the name at **registration** time, in `register_entity`. This plugin
owns its own lookup contract, and the fix repairs every emitter vintage at once —
deployed `ovos-workshop` releases will keep emitting the munged name forever, so
fixing only the producer leaves every already-deployed skill container broken.

Two more things fall out of that:

- **Exactly-once.** `ovos-workshop >= 9.3` dual-emits one entity (munged legacy
  twin + clean spec twin). Once both collapse to the same canonical name,
  registration has to be idempotent, mirroring the intent dedup from #89. The
  manifest now replaces instead of appending.
- **`EntityManager.remove` was broken.** Entities are stored as
  `<skill_id>:{<entity>}` (`Entity.wrap_name` puts the brace around the entity
  token only), but removal built `{<skill_id>:<entity>}` — which matched nothing.
  Namespaced entities were therefore unremovable, and `TrainingManager.add`'s
  replace-on-re-register silently stacked duplicate objects. Removal now builds
  the same key it stores under; bare global entities are unchanged.

## Red → green

`tests/test_entity_name_collapse.py` registers an entity via the **real** munged
legacy payload (the fixture asserts it equals what workshop actually builds), then
asserts a slot-constrained intent rejects out-of-entity utterances.

Against current `dev`, 5 of the 9 new tests fail:

```
FAILED TestLegacyEntityNameCollapse::test_entity_is_registered_under_the_clean_name
FAILED TestLegacyEntityNameCollapse::test_munged_legacy_entity_constrains_the_slot
FAILED TestEntityRegistrationExactlyOnce::test_manifest_has_exactly_one_entry
FAILED TestEntityRemoval::test_namespaced_entity_is_actually_removed_from_the_engine
FAILED TestEntityRemoval::test_reregistering_an_entity_does_not_stack_duplicates
```

With the fix: 9 passed. Full suite: **104 passed, 2 skipped**.

## Merge independence

`OpenVoiceOS/ovos-workshop` has a sibling PR that stops emitting the munged name.
The two are **independent** — each is sufficient on its own, and they compose
without conflict (a clean name is already a fixed point of the collapse here).
This one is the load-bearing half: it is the only one that fixes skills running
against an older workshop.

## Model usage

Written by Claude Fable 5 (`claude-fable-5`) via Claude Code. Claims verified
against current `dev` source of both repos; test results are from a real run in a
throwaway venv. Model re-check is not human review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved entity removal for both plain and namespaced entity names.
  - Normalized legacy entity names to prevent duplicate registrations.
  - Ensured entity cleanup and re-registration behave consistently.

- **Tests**
  - Added coverage for entity normalization, deduplication, removal, registration, and training workflows.

- **Chores**
  - Added temporary files and directories to ignored repository paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->