### PR TITLE
fix: entity value sets bias confidence instead of closing the vocabulary

### DIFF
--- a/ovos_padatious/intent.py
+++ b/ovos_padatious/intent.py
@@ -34,8 +34,12 @@ class Intent(Trainable):
         possible_matches = [MatchData(self.name, sent)]
         for pi in self.pos_intents:
             entity = entities.find(self.name, pi.token) if entities else None
+            # this intent's own template vocabulary, already trained and
+            # persisted by SimpleIntent - lets PosIntent tell a slot value
+            # apart from template words that leaked into the span
+            literals = self.simple_intent.ids
             for i in list(possible_matches):
-                possible_matches += pi.match(i, entity)
+                possible_matches += pi.match(i, entity, literals)
 
         possible_matches = [i for i in possible_matches if i.conf >= 0.0]
 

--- a/ovos_padatious/pos_intent.py
+++ b/ovos_padatious/pos_intent.py
@@ -18,6 +18,60 @@ from typing import List, Optional, Any
 from ovos_padatious.entity_edge import EntityEdge
 from ovos_padatious.match_data import MatchData
 
+#: Lowest contribution a registered entity value set may make to a candidate.
+#:
+#: Per OVOS-INTENT-1 5.4 an ``.entity`` file (or ``add_entity`` call) is a set
+#: of *training hints*: example values that bias scoring towards the expected
+#: shape of a slot. It is NOT a closed vocabulary. The spec is normative here -
+#: an engine MAY use the set to *score* a slot, but MUST NOT treat it as an
+#: exhaustive allow-list, so a candidate whose slot fills with a value outside
+#: the set MUST remain matchable.
+#:
+#: So the raw ``Entity.match`` score is mapped through :func:`hint_confidence`,
+#: which lifts it onto a floor without ever letting it collapse a candidate.
+ENTITY_HINT_FLOOR = 0.8
+
+#: Raw score at and above which :func:`hint_confidence` is the identity.
+#:
+#: ``Entity.match`` is a neural net, so a *listed* value scores about 0.91, not
+#: 1.0. Anything that rescales the whole range - the obvious
+#: ``1 - bias * (1 - raw)`` - lifts those to ~0.98 and *promotes* in-list
+#: matches across a pipeline confidence band ("what is the weather in porto
+#: today" moved 0.9318 -> 0.9502, crossing ``conf_high``). Keeping the map an
+#: identity from here up makes that impossible: for a listed value the
+#: arithmetic is bit-identical to the pre-fix behaviour.
+ENTITY_HINT_IDENTITY = 0.9
+
+#: Raw ``Entity.match`` score above which the value set is considered to have
+#: actually recognised a span. Only then is it used to discard rival spans.
+ENTITY_HINT_RECOGNISED = 0.5
+
+
+def hint_confidence(raw: float) -> float:
+    """Map a raw ``Entity.match`` score to a slot-scoring contribution.
+
+    The map is **strictly increasing** on ``[0, 1]``, and that is the whole
+    design. Two properties have to hold at once:
+
+    * a value the set does not know must not collapse its candidate, so the
+      map has a floor at :data:`ENTITY_HINT_FLOOR` and never returns less;
+    * the set must still be able to *rank* rival spans that it recognises
+      only weakly. A flat floor cannot: with two spans both mapping to 0.8,
+      the tie falls to ``pos_conf``, which prefers the shorter span, and
+      "play song 2" extracts "2" instead of "song 2". Strict monotonicity is
+      what keeps a partial recognition worth more than none at all.
+
+    Below :data:`ENTITY_HINT_IDENTITY` the score is ramped from the floor by a
+    square root, so the interesting, weakly-recognised end of the range gets
+    most of the resolution. At and above it the map is the identity, which is
+    what stops a listed value from ever gaining confidence.
+    """
+    raw = min(1.0, max(0.0, raw))
+    if raw >= ENTITY_HINT_IDENTITY:
+        return raw
+    span = ENTITY_HINT_IDENTITY - ENTITY_HINT_FLOOR
+    return ENTITY_HINT_FLOOR + span * math.sqrt(raw / ENTITY_HINT_IDENTITY)
+
 
 class PosIntent:
     """
@@ -35,13 +89,18 @@ class PosIntent:
             EntityEdge(+1, token, intent_name)
         ]
 
-    def match(self, orig_data: Any, entity: Optional[Any] = None) -> List[MatchData]:
+    def match(self, orig_data: Any, entity: Optional[Any] = None,
+              template_tokens: Optional[Any] = None) -> List[MatchData]:
         """
         Matches the original data against the token and extracts entities.
 
         Args:
             orig_data (Any): Original data containing the sentence to match.
             entity (Optional[Any]): An entity to match against. Defaults to None.
+            template_tokens (Optional[Any]): Container supporting ``in`` that
+                holds the literal tokens of this intent's own templates. Used
+                only to discard a rival span that swallows template literals
+                around a span the value set recognised. Defaults to None.
 
         Returns:
             List[MatchData]: A list of possible matches with their corresponding data.
@@ -57,7 +116,7 @@ class PosIntent:
                 return False
             return all(not orig_data.sent[p].startswith('{') for p in range(l_pos, r_pos + 1))
 
-        possible_matches: List[MatchData] = []
+        scored: List[tuple] = []
         for l_conf, l_pos in l_matches:
             if l_conf < 0.2:
                 continue
@@ -68,7 +127,14 @@ class PosIntent:
                 extracted = orig_data.sent[l_pos:r_pos + 1]
 
                 pos_conf = (l_conf - 0.5 + r_conf - 0.5) / 2 + 0.5
-                ent_conf = entity.match(extracted) if entity else 1
+                # entity value sets are training hints, not vocabularies: the
+                # set may lift a candidate above the floor but never sink one
+                # below it, so an unlisted value is never collapsed (and so
+                # never discarded) - and an in-list value never *gains*
+                raw = 1.0
+                if entity:
+                    raw = min(1.0, max(0.0, entity.match(extracted)))
+                ent_conf = hint_confidence(raw) if entity else 1.0
 
                 new_sent = orig_data.sent[:l_pos] + [self.token] + orig_data.sent[r_pos + 1:]
                 new_matches = orig_data.matches.copy()
@@ -77,9 +143,41 @@ class PosIntent:
                 extra_conf = math.sqrt(pos_conf * ent_conf) - 0.5
                 data = MatchData(orig_data.name, new_sent, new_matches,
                                  orig_data.conf + extra_conf)
-                possible_matches.append(data)
+                scored.append((raw, l_pos, r_pos, data))
 
-        return possible_matches
+        # With no entity every span scores raw 1.0, so there is no "recognised"
+        # span to discriminate around and the value set steers nothing. Bail
+        # out before the filter, or an entity-less slot would silently lose
+        # spans to an arbitrary tie-broken "best".
+        if not scored or entity is None or template_tokens is None:
+            return [data for _, _, _, data in scored]
+
+        # A value set still steers *which* words fill the slot, but only in the
+        # one case where the alternative is unambiguously wrong: a rival span
+        # that strictly contains a span the set recognised, and whose extra
+        # words are literals of this intent's own templates. "make a timer for
+        # 3 minute" against a numeric value set drops "timer for 3" in favour
+        # of "3", because "timer" and "for" are template literals.
+        #
+        # Anything else survives. In particular a multi-word out-of-list value
+        # whose tail happens to be listed keeps its full span - "weather in new
+        # london" yields "new london", not "london", because "new" is not a
+        # template literal. Discarding on raw score alone truncated those.
+        best_raw, best_l, best_r, _ = max(scored, key=lambda s: s[0])
+        if best_raw < ENTITY_HINT_RECOGNISED:
+            return [data for _, _, _, data in scored]
+
+        def swallows_only_literals(l_pos: int, r_pos: int) -> bool:
+            if (l_pos, r_pos) == (best_l, best_r):
+                return False
+            if l_pos > best_l or r_pos < best_r:
+                return False  # not a strict superset of the recognised span
+            extra = (list(range(l_pos, best_l)) +
+                     list(range(best_r + 1, r_pos + 1)))
+            return all(orig_data.sent[p] in template_tokens for p in extra)
+
+        return [data for _, l_pos, r_pos, data in scored
+                if not swallows_only_literals(l_pos, r_pos)]
 
     def save(self, prefix: str) -> None:
         """

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -159,9 +159,13 @@ class TestIntentContainer(unittest.TestCase):
         assert data.conf > 0.5
         assert data['ent'] == 'one'
 
+        # a value set is a training hint, not a closed vocabulary
+        # (OVOS-INTENT-1 5.4): an unlisted value scores lower than a listed
+        # one, but it is still captured and still matches.
         data = self.cont.calc_intent('test two')
         assert high_conf > data.conf
-        assert 'ent' not in data
+        assert data.conf > 0.8
+        assert data['ent'] == 'two'
 
     def test_regular_entities(self):
         self._test_entities('')
@@ -178,7 +182,9 @@ class TestIntentContainer(unittest.TestCase):
         self.cont.add_intent('thing', ['A {thing}'])
         self.cont.add_entity('thing', ['thing'])
         self.cont.train(False)
-        assert self.cont.calc_intent('A dog').conf < 0.5
+        # 'dog' is not in the value set, so it is penalised but still matches
+        assert self.cont.calc_intent('A dog').matches == {'thing': 'dog'}
+        assert 0.8 < self.cont.calc_intent('A dog').conf < 1.0
         assert self.cont.calc_intent('A thing').conf == 1.0
         self.cont.remove_entity('thing')
         assert self.cont.calc_intent('A dog').conf == 1.0

--- a/tests/test_entity_hints.py
+++ b/tests/test_entity_hints.py
@@ -1,0 +1,407 @@
+"""Entity value sets are training hints, never closed vocabularies.
+
+OVOS-INTENT-1 §5.4: an ``.entity`` file lists *example* values that bias
+scoring. A value outside the list must still fill the slot and must still
+produce a viable match.
+"""
+import tempfile
+
+import pytest
+
+from ovos_padatious.intent_container import IntentContainer
+from ovos_padatious.match_data import MatchData
+
+
+@pytest.fixture()
+def container():
+    return IntentContainer(tempfile.mkdtemp())
+
+
+def test_out_of_list_value_still_matches(container):
+    """The zzyzxvania repro: unknown slot value must not close the vocabulary."""
+    container.add_intent('time', ['current time in {location}'])
+    container.add_entity('location', ['africa', 'london', 'paris'])
+    container.train(debug=False)
+
+    match = container.calc_intent('current time in zzyzxvania')
+    assert match.name == 'time'
+    assert match.matches.get('location') == 'zzyzxvania'
+    assert match.conf > 0.8
+
+
+def test_in_list_value_is_unpenalised(container):
+    """Protect the pre-existing in-list behaviour."""
+    container.add_intent('time', ['current time in {location}'])
+    container.add_entity('location', ['africa', 'london', 'paris'])
+    container.train(debug=False)
+
+    match = container.calc_intent('current time in london')
+    assert match.name == 'time'
+    assert match.matches.get('location') == 'london'
+    assert match.conf == pytest.approx(1.0, abs=1e-6)
+
+
+def test_in_list_outranks_out_of_list(container):
+    """The list acts as a score: on ONE utterance, the intent whose value set
+    knows the value must win over the one whose set does not.
+
+    This is a *within-span* property. Across different spans a longer
+    out-of-list value can still beat a shorter in-list one ("new york city"
+    beats "new york"), exactly as it does pre-fix.
+    """
+    container.add_intent('known', ['weather in {city}'])
+    container.add_intent('unknown', ['weather in {town}'])
+    container.add_entity('city', ['london'])
+    container.add_entity('town', ['paris'])
+    container.train(debug=False)
+
+    # same utterance, same template shape: only the value sets differ
+    match = container.calc_intent('weather in london')
+    assert match.name == 'known'
+    assert match.matches.get('city') == 'london'
+
+    # and a value neither set knows still matches, with the slot captured
+    other = container.calc_intent('weather in zzyzxvania')
+    assert other.conf > 0.8
+    assert 'zzyzxvania' in other.matches.values()
+    assert other.conf < match.conf
+
+
+def test_multi_word_value_with_listed_tail_is_not_truncated(container):
+    """A rival span may only be dropped when the words it swallows are
+    template literals - never merely because its tail is a listed value."""
+    container.add_intent('weather', ['weather in {location}'])
+    container.add_entity('location', ['london', 'york', 'porto'])
+    container.train(debug=False)
+
+    match = container.calc_intent('weather in new london')
+    assert match.name == 'weather'
+    assert match.matches.get('location') == 'new london'
+    assert match.conf > 0.8
+
+
+def test_multi_word_value_with_listed_tail_mid_utterance(container):
+    container.add_intent('play', ['play {song}'])
+    container.add_entity('song', ['rain', 'fire'])
+    container.train(debug=False)
+
+    match = container.calc_intent('play ring of fire')
+    assert match.name == 'play'
+    assert match.matches.get('song') == 'ring of fire'
+    assert match.conf > 0.8
+
+
+def test_template_literals_are_still_stripped_from_the_span(container):
+    """The one case the discriminator does fire on: the swallowed words are
+    literals of the intent's own templates."""
+    container.add_intent('timer', ['set a timer for {time} minutes',
+                                   'make a {time} minute timer'])
+    container.add_entity('time', ['#', '##', '#:##', '##:##'])
+    container.train(debug=False)
+
+    match = container.calc_intent('make a timer for 3 minute')
+    assert match.name == 'timer'
+    assert match.matches == {'time': '3'}
+
+
+def test_blocked_skill_wave_datetime(container):
+    """ovos-skill-date-time#264: location entity without the asked-for city."""
+    container.add_intent('current_time', [
+        'what time is it in {location}',
+        'current time in {location}',
+    ])
+    container.add_entity('location', ['london', 'paris', 'new york'])
+    container.train(debug=False)
+
+    match = container.calc_intent('what time is it in Coimbra')
+    assert match.name == 'current_time'
+    assert match.matches.get('location') == 'coimbra'
+    assert match.conf > 0.8
+
+
+def test_blocked_skill_wave_mark1_brightness(container):
+    """ovos-skill-mark1-ctrl#38: '#' placeholder lines in a brightness entity.
+
+    ``#``/``##`` are digit placeholders, matching padacioso's ``#`` -> ``\\d``
+    convention; padatious implements it in ``IdManager.adj_token``, which
+    folds any digit run to ``#`` before scoring. So a numeric value is an
+    in-list hit here, and any other value is still captured as a hint miss.
+    """
+    container.add_intent('brightness', ['set eye brightness to {level} percent',
+                                        'set eye brightness to {level}'])
+    container.add_entity('level', ['full', 'half', '#', '##'])
+    container.train(debug=False)
+
+    match = container.calc_intent('set eye brightness to 42 percent')
+    assert match.name == 'brightness'
+    assert match.matches.get('level') == '42'
+    assert match.conf > 0.8
+
+    named = container.calc_intent('set eye brightness to half')
+    assert named.matches.get('level') == 'half'
+    assert named.conf > 0.8
+
+    # the numeric case above passes even with a hard allow-list, because '42'
+    # folds to the in-list '##'. These do not: they are genuinely out-of-list.
+    word = container.calc_intent('set eye brightness to dim')
+    assert word.name == 'brightness'
+    assert word.matches.get('level') == 'dim'
+    assert word.conf > 0.8
+
+    phrase = container.calc_intent('set eye brightness to very dim')
+    assert phrase.name == 'brightness'
+    assert phrase.matches.get('level') == 'very dim'
+    assert phrase.conf > 0.8
+
+
+def test_empty_entity_list(container):
+    container.add_intent('time', ['current time in {location}'])
+    container.add_entity('location', [])
+    container.train(debug=False)
+
+    match = container.calc_intent('current time in london')
+    assert match.matches.get('location') == 'london'
+    assert match.conf > 0.8
+
+
+def test_entity_registered_after_training(container):
+    container.add_intent('time', ['current time in {location}'])
+    container.train(debug=False)
+    container.add_entity('location', ['london'])
+    container.train(debug=False)
+
+    match = container.calc_intent('current time in zzyzxvania')
+    assert match.matches.get('location') == 'zzyzxvania'
+    assert match.conf > 0.8
+
+
+def test_unicode_out_of_list_value(container):
+    container.add_intent('time', ['current time in {location}'])
+    container.add_entity('location', ['london'])
+    container.train(debug=False)
+
+    match = container.calc_intent('current time in Köln')
+    assert match.matches.get('location') == 'köln'
+    assert match.conf > 0.8
+
+
+def test_multi_word_out_of_list_value(container):
+    container.add_intent('time', ['current time in {location}'])
+    container.add_entity('location', ['london'])
+    container.train(debug=False)
+
+    match = container.calc_intent('current time in vila nova de gaia')
+    assert match.matches.get('location') == 'vila nova de gaia'
+    assert match.conf > 0.8
+
+
+# ---------------------------------------------------------------------------
+# Direct PosIntent.match tests.
+#
+# The discriminator has branches that end-to-end tests cannot reach, because
+# the raw scores come from a neural net and cannot be steered from an
+# utterance. These drive PosIntent.match with a stub entity so each branch is
+# pinned by a test that fails when the branch is removed.
+# ---------------------------------------------------------------------------
+
+class _StubEntity:
+    """Entity whose score for a span is looked up, not learned."""
+
+    def __init__(self, scores, default=0.0):
+        self.scores = scores
+        self.default = default
+
+    def match(self, sent):
+        return self.scores.get(' '.join(sent), self.default)
+
+
+def _pos_intent(container, intent_name):
+    intent = [o for o in container.intents.objects if o.name == intent_name][0]
+    return intent.pos_intents[0], intent.simple_intent.ids
+
+
+def _spans(results, token):
+    return {' '.join(r.matches[token]) for r in results}
+
+
+@pytest.fixture()
+def timer_grammar():
+    c = IntentContainer(tempfile.mkdtemp())
+    c.add_intent('timer', ['set a timer for {time} minutes',
+                           'make a {time} minute timer'])
+    c.add_entity('time', ['#', '##'])
+    c.train(debug=False)
+    return c
+
+
+def test_weakly_recognised_span_does_not_discard_rivals(timer_grammar):
+    """Mutant killed: ENTITY_HINT_RECOGNISED = 0.0.
+
+    A best raw score below the threshold means the value set has not really
+    recognised anything, so it may not throw rival spans away - even ones made
+    only of template literals.
+    """
+    pi, literals = _pos_intent(timer_grammar, 'timer')
+    sent = ['make', 'a', 'timer', 'for', '3', 'minute']
+    orig = MatchData('timer', sent)
+
+    weak = _StubEntity({'3': 0.4})  # in (0, ENTITY_HINT_RECOGNISED)
+    kept = _spans(pi.match(orig, weak, literals), '{time}')
+    assert '3' in kept
+    assert 'timer for 3' in kept, "a weak best score must not discard rivals"
+
+    # and with the same span scored above the threshold, the rival IS dropped
+    strong = _StubEntity({'3': 0.9})
+    kept = _spans(pi.match(orig, strong, literals), '{time}')
+    assert '3' in kept
+    assert 'timer for 3' not in kept
+
+
+def test_no_entity_never_discards_spans(timer_grammar):
+    """Pins the contract behind the ``entity is None`` guard.
+
+    With no value set every span scores raw 1.0, so there is no recognised
+    span to discriminate around and no span may be dropped: an entity-less
+    slot must behave exactly as if the discriminator did not exist.
+
+    Note this test does NOT kill the mutant that deletes ``entity is None``
+    from the guard, and cannot: with all raw scores equal, ``max`` picks the
+    lexicographically first span, and no other span is then a strict superset
+    of it that swallows only template literals. The guard is defensive - it
+    makes the intent explicit and stops a future change to the tie-break from
+    silently eating spans. This test pins the observable contract instead.
+    """
+    pi, literals = _pos_intent(timer_grammar, 'timer')
+    sent = ['make', 'a', 'timer', 'for', '3', 'minute']
+    orig = MatchData('timer', sent)
+
+    guarded = _spans(pi.match(orig, None, literals), '{time}')
+    no_discriminator = _spans(pi.match(orig, None, None), '{time}')
+    assert guarded == no_discriminator
+
+    # a registered value set, by contrast, does steer the span
+    with_entity = _spans(pi.match(orig, _StubEntity({'3': 0.9}), literals),
+                         '{time}')
+    assert 'timer for 3' in guarded
+    assert 'timer for 3' not in with_entity
+
+
+def test_subset_span_survives(timer_grammar):
+    """Mutant killed: turning the strict-superset ``return False`` into a fall
+    through.
+
+    A span *contained* in the recognised one swallows no extra tokens, so
+    ``all([])`` is vacuously True and it would be discarded by a discriminator
+    that forgot to check containment direction.
+    """
+    pi, literals = _pos_intent(timer_grammar, 'timer')
+    sent = ['make', 'a', 'timer', 'for', '3', 'minute']
+    orig = MatchData('timer', sent)
+
+    # score the WIDE span as the recognised one; 'for 3' and '3' are subsets
+    entity = _StubEntity({'timer for 3': 0.9})
+    kept = _spans(pi.match(orig, entity, literals), '{time}')
+    assert 'timer for 3' in kept
+    assert '3' in kept, "a subset of the recognised span must survive"
+
+
+def test_in_list_value_never_gains_confidence():
+    """Mutant killed: rescaling instead of flooring.
+
+    ``Entity.match`` is a neural net, so a listed value scores ~0.91, not 1.0.
+    A rescale would lift that and promote in-list matches across a pipeline
+    confidence band. Pin the pre-fix value: this utterance measures 0.9318 on
+    dev and must not reach conf_high (0.95).
+    """
+    c = IntentContainer(tempfile.mkdtemp())
+    c.add_intent('weather', ['what is the weather in {location}',
+                             'weather in {location}',
+                             'weather for {location} today'])
+    c.add_entity('location', ['london', 'york', 'porto', 'the hague'])
+    c.train(debug=False)
+
+    match = c.calc_intent('what is the weather in porto today')
+    assert match.matches.get('location') == 'porto'
+    assert match.conf == pytest.approx(0.9318, abs=5e-3)
+    assert match.conf < 0.95, "in-list match must not be promoted to conf_high"
+
+    # exact template matches are untouched too
+    assert c.calc_intent('weather in porto').conf == pytest.approx(1.0, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Span ranking below the floor.
+#
+# A flat floor (``max(raw, 0.8)``) is constant on [0, 0.8], so two spans the
+# value set recognises only weakly score identically and the tie falls to
+# pos_conf, which prefers the shorter span. These pin the strictly increasing
+# map that fixes it.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def play_grammar():
+    c = IntentContainer(tempfile.mkdtemp())
+    c.add_intent('play', ['play {song}', 'play the song {song}',
+                          'play {song} by {artist}'])
+    c.add_entity('song', ['fire', 'rain', 'song', 'wall'])
+    c.add_entity('artist', ['adele', 'queen'])
+    c.train(debug=False)
+    return c
+
+
+def test_hint_confidence_is_strictly_increasing():
+    """The property the whole design rests on."""
+    from ovos_padatious.pos_intent import (ENTITY_HINT_FLOOR,
+                                           ENTITY_HINT_IDENTITY,
+                                           hint_confidence)
+
+    values = [i / 200.0 for i in range(201)]
+    scores = [hint_confidence(v) for v in values]
+    for lo, hi in zip(scores, scores[1:]):
+        assert hi > lo, "hint_confidence must be strictly increasing"
+
+    # never collapses a candidate...
+    assert hint_confidence(0.0) == pytest.approx(ENTITY_HINT_FLOOR)
+    # ...and never inflates a value the net actually recognises
+    for v in (ENTITY_HINT_IDENTITY, 0.93, 0.95, 1.0):
+        assert hint_confidence(v) == pytest.approx(v)
+
+
+def test_partially_recognised_span_beats_shorter_rival(play_grammar):
+    """'song' is a listed value, so 'song 2' is partially recognised and must
+    outrank the bare '2' that pos_conf prefers. A flat floor scored both 0.8
+    and returned '2'."""
+    match = play_grammar.calc_intent('play song 2')
+    assert match.name == 'play'
+    assert match.matches.get('song') == 'song 2'
+    assert match.conf > 0.8
+
+
+def test_out_of_list_span_not_truncated_to_listed_tail(play_grammar):
+    """Same shape, fully unrecognised head."""
+    match = play_grammar.calc_intent('play ring of fire')
+    assert match.matches.get('song') == 'ring of fire'
+    assert match.conf > 0.8
+
+
+def test_weather_multiword_out_of_list_value(container):
+    """'city hall' is wholly out of list; dev dropped the candidate entirely."""
+    container.add_intent('weather', ['weather in {location}',
+                                     'what is the weather in {location}',
+                                     'weather for {location} today'])
+    container.add_entity('location', ['london', 'york', 'porto', 'the hague'])
+    container.train(debug=False)
+
+    match = container.calc_intent('weather in city hall')
+    assert match.name == 'weather'
+    assert match.matches.get('location') == 'city hall'
+    assert match.conf > 0.8
+
+
+def test_span_choice_matches_dev_on_ambiguous_filler(play_grammar):
+    """Parity pin, not a fix: 'some' is not in any template, so the whole tail
+    is the slot value. dev extracts 'some song two' here and so do we - the
+    only difference is that dev scored it 0.75 and we score it in medium."""
+    match = play_grammar.calc_intent('play some song two')
+    assert match.matches.get('song') == 'some song two'
+    assert match.conf > 0.8


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

A registered entity was acting as a hard allow-list instead of a hint. If you registered a `location` entity with sample values like `africa`/`london`/`paris` and then asked about a place that wasn't in that list, the whole intent match collapsed to zero confidence and the slot got dropped — worse than if you'd never registered the entity at all. The cause is in `PosIntent.match`: an unknown value produced a negative confidence contribution, and `Intent.match` throws out any candidate with negative confidence, which is exactly the candidates that had the slot filled.

This isn't just a bug, it's a violation of OVOS-INTENT-1 §5.4, which explicitly says an engine may use a registered value set to score a match but must not treat it as an exhaustive allow-list — a slot filled with an out-of-set value must stay matchable. So the fix here is spec-mandated.

The core change stops the value set from ever pushing a candidate down. A raw score from the entity net is mapped onto a floor of 0.8, so an unknown value is lifted rather than collapsed. I first tried a two-sided rescale that lifted the whole range, but adversarial review caught that it also inflated values already in the list — enough to push some matches across the pipeline's high-confidence threshold, a real behavior change that's out of scope here. So the map is now the identity for anything the net already scores at 0.9 or above, which is where genuinely listed values land. For those, the math is bit-identical to `dev`.

The second round of review then caught the opposite mistake. A flat floor is a constant, so two spans the value set only half-recognizes score exactly the same, the tie falls through to the positional score, and that prefers shorter spans — "play song 2" started extracting just "2" even though "song" is a listed value. The map is now strictly increasing across the whole range, ramped up from the floor by a square root so the weakly-recognized end gets most of the resolution. Partial recognition is worth more than none again, and "play song 2" extracts "song 2".

There's a second piece: naively lifting unknown values regressed span selection, because a wider matching span could out-score a correct narrower one once the penalty for being unrecognized was gone (e.g. "timer for 3 minutes" started extracting "timer for 3" instead of "3"). An earlier revision fixed this with a raw-score ratio cutoff, but adversarial review found that broke multi-word out-of-list values whose last word happened to be in the list — "weather in new london" would wrongly extract just "london." The final approach only discards a wider rival span when the extra words it swallows are literal words from the intent's own template (like "timer" and "for"), never when they're part of the value itself (like "new" in "new london"). This is a defensive, narrowly-scoped rule, and testing confirmed it doesn't change behavior in the ordinary case where nothing is registered.

The two numbers are pinned from both sides. The floor is 0.8 because a clean match on an unlisted value has to clear the pipeline's medium band. The identity point is 0.9 because that's just below what a genuinely listed value actually scores (~0.91), so listed values pass through untouched. Padatious training is nondeterministic, so tighter margins would be flaky.

Regression tests grew to 145 cases, checked against five code states. `origin/dev` fails 12 of them, the ratio-cutoff revision fails 2 (span truncation), the two-sided-rescale revision fails 1 (in-list inflation), the flat-floor revision fails 2 (the span ranking above), and this version passes all 145, stable across three runs. Some of the trickier properties are pinned by tests that talk directly to `PosIntent.match` with a stub entity, because the underlying scores come from a neural net and can't be steered from natural-language input. Two existing tests that had enshrined the old allow-list behavior were rewritten to the corrected contract.

One correction to an earlier version of this description: it blamed a one-off CI failure on a guard added at the same time. Review showed that guard can't have caused it, and the failure never reproduced locally in either direction. That CI failure is still unexplained; the likely cause is flakiness under parallel test execution. Everything has been green since.

Left out of scope: enabling the pipeline's medium-confidence stage by default is a decision for the maintainer, not done here — without it, an out-of-list match is correct internally but invisible on stock installs, since the default pipeline only runs the high-confidence stage. Also out of scope, and checked directly against current source: a reported dedup asymmetry between `padatious:register_entity` and `ovos.entity.register` turned out to belong to a different repo (padacioso), not this one — both wire paths here already go through the same dedup logic, so there's nothing to fix.

This PR blocks three downstream skill PRs that depend on this hint-semantics fix: OpenVoiceOS/ovos-skill-date-time#264, OpenVoiceOS/ovos-skill-mark1-ctrl#38, and OpenVoiceOS/ovos-skill-pokepedia#26, plus the rest of the entity-wave batch.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved entity matching for values not seen during training.
  * Preserved matching for unknown, Unicode, multi-word, date-time, and brightness values.
  * Improved selection of overlapping entity spans and confidence scoring.
  * Prevented template words from incorrectly interfering with recognized entity matches.

* **Tests**
  * Added comprehensive coverage for entity hints, confidence behavior, and ambiguous matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->