### PR TITLE
fix: bound entity net training and score listed values exactly

### DIFF
--- a/docs/prerelease-quirks.md
+++ b/docs/prerelease-quirks.md
@@ -4,6 +4,31 @@ This page tracks user-visible behavior changes since the last stable release,
 `1.4.3`. Newest first. Package name on PyPI is `ovos-padatious`; this repo is
 `ovos-padatious-pipeline-plugin`. Resets to empty at the next stable release.
 
+## 2.0.5a1 — entity training bounded; listed values score exactly 1.0
+
+Entity value sets of any size now train in roughly constant time. The
+per-entity neural net trains on a deterministic, evenly-strided subset of at
+most 128 positive and 128 negative sentences; past a few hundred diverse
+samples the net stopped converging, so every training restart burned its
+full epoch budget and a pair of ~2200-value entities took over ten minutes
+to train (breaking service-ready timeouts on cold boots). Engines own
+handling unbounded entity data; this is the subset choice.
+
+The full value set is kept for an exact-match fast path: a listed value now
+scores exactly `1.0` through `Entity.match`, deterministically, instead of
+the ~0.91 the net gave it. Behavior change: an in-list slot value scores the
+same as if no entity were attached — on a default (high-only) pipeline this
+restores routing for utterances that registering an entity had silently
+pushed below `conf_high` (e.g. 0.9318 back to ~0.9547). Out-of-list values
+keep the floor-ramped hint band and still rank below listed ones.
+
+The training-cache hash is salted with a format version, so the whole cache
+— intents included — retrains once on first boot after upgrade and
+regenerates with the new `.samples` sidecar. Containers restored through
+`instantiate_from_disk` bypass that check: a pre-sidecar cache loaded that
+way keeps net scoring for listed values (exactly the old behavior) until
+its entities are registered again.
+
 ## 2.0.4a1 — `tokenize()` no longer splits underscore/digit slot names
 
 `{thing_name}` used to tokenize as `['{thing', '_', 'name}']` instead of one

--- a/ovos_padatious/entity.py
+++ b/ovos_padatious/entity.py
@@ -12,11 +12,60 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from os.path import join
-from typing import Any, Type
+import json
+from os.path import isfile, join
+from typing import Any, List, Set, Tuple, Type
 
 from ovos_padatious.simple_intent import SimpleIntent
 from ovos_padatious.trainable import Trainable
+
+#: Upper bound on sentences fed to the entity's neural net, positives and
+#: negatives each. Net training cost grows with vocabulary width times sample
+#: count times epochs, and past a few hundred diverse samples the net stops
+#: converging, so every training restart burns its full epoch budget: an
+#: unbounded pair of ~2200-value entities trains for over ten minutes where
+#: the capped net takes about a second. The net only needs enough examples to
+#: generalise over *unseen* values — every known value is matched exactly
+#: through ``Entity.samples`` instead, so capping the net's diet loses
+#: nothing for listed values.
+ENTITY_NET_TRAINING_CAP = 128
+
+
+class _CappedTrainData:
+    """View of a ``TrainData`` that bounds one entity's positive and negative
+    sentence streams to a deterministic, evenly-strided subset."""
+
+    def __init__(self, data: Any, name: str,
+                 keep_mine: Set[Tuple[str, ...]],
+                 keep_other: Set[Tuple[str, ...]]) -> None:
+        self._data = data
+        self._name = name
+        self._keep_mine = keep_mine
+        self._keep_other = keep_other
+
+    def my_sents(self, name: str):
+        seen = set()
+        for sent in self._data.my_sents(name):
+            key = tuple(sent)
+            if key in self._keep_mine and key not in seen:
+                seen.add(key)
+                yield sent
+
+    def other_sents(self, name: str):
+        seen = set()
+        for sent in self._data.other_sents(name):
+            key = tuple(sent)
+            if key in self._keep_other and key not in seen:
+                seen.add(key)
+                yield sent
+
+
+def _strided_subset(sents: List[Tuple[str, ...]], cap: int) -> Set[Tuple[str, ...]]:
+    """Deterministic evenly-strided pick of ``cap`` items from sorted input."""
+    if len(sents) <= cap:
+        return set(sents)
+    step = (len(sents) - 1) / (cap - 1)
+    return {sents[round(i * step)] for i in range(cap)}
 
 
 class Entity(SimpleIntent, Trainable):
@@ -31,6 +80,26 @@ class Entity(SimpleIntent, Trainable):
         """
         SimpleIntent.__init__(self, name)
         Trainable.__init__(self, name, *args, **kwargs)
+        #: Every known value as a token tuple. Exact lookups bypass the net:
+        #: a listed value always scores 1.0, deterministically, regardless of
+        #: how the (retraining-nondeterministic) net would score it.
+        self.samples: Set[Tuple[str, ...]] = set()
+
+    def match(self, sent: List[str]) -> float:
+        if tuple(sent) in self.samples:
+            return 1.0
+        return SimpleIntent.match(self, sent)
+
+    def train(self, train_data: Any) -> None:
+        mine = sorted({tuple(s) for s in train_data.my_sents(self.name)})
+        self.samples = set(mine)
+        other = sorted({tuple(s) for s in train_data.other_sents(self.name)})
+        if len(mine) > ENTITY_NET_TRAINING_CAP or len(other) > ENTITY_NET_TRAINING_CAP:
+            train_data = _CappedTrainData(
+                train_data, self.name,
+                _strided_subset(mine, ENTITY_NET_TRAINING_CAP),
+                _strided_subset(other, ENTITY_NET_TRAINING_CAP))
+        SimpleIntent.train(self, train_data)
 
     @staticmethod
     def verify_name(token: str) -> None:
@@ -73,6 +142,8 @@ class Entity(SimpleIntent, Trainable):
         """
         prefix = join(folder, self.name)
         SimpleIntent.save(self, prefix)
+        with open(prefix + '.samples', 'w', encoding='utf-8') as f:
+            json.dump(sorted(list(s) for s in self.samples), f, ensure_ascii=False)
         self.save_hash(prefix)
 
     @classmethod
@@ -89,5 +160,9 @@ class Entity(SimpleIntent, Trainable):
             Entity: The loaded Entity instance.
         """
         self = super(Entity, cls).from_file(name, join(folder, name))
+        samples_file = join(folder, name) + '.samples'
+        if isfile(samples_file):
+            with open(samples_file, encoding='utf-8') as f:
+                self.samples = {tuple(s) for s in json.load(f)}
         self.load_hash(join(folder, name))
         return self

--- a/ovos_padatious/pos_intent.py
+++ b/ovos_padatious/pos_intent.py
@@ -33,13 +33,14 @@ ENTITY_HINT_FLOOR = 0.8
 
 #: Raw score at and above which :func:`hint_confidence` is the identity.
 #:
-#: ``Entity.match`` is a neural net, so a *listed* value scores about 0.91, not
-#: 1.0. Anything that rescales the whole range - the obvious
-#: ``1 - bias * (1 - raw)`` - lifts those to ~0.98 and *promotes* in-list
-#: matches across a pipeline confidence band ("what is the weather in porto
-#: today" moved 0.9318 -> 0.9502, crossing ``conf_high``). Keeping the map an
-#: identity from here up makes that impossible: for a listed value the
-#: arithmetic is bit-identical to the pre-fix behaviour.
+#: A *listed* value short-circuits through ``Entity.samples`` to a raw score
+#: of exactly 1.0, which the identity passes through unchanged: the slot
+#: scores bit-identically to a hint-less slot (``ent_conf == 1.0``), so
+#: attaching an entity never penalises the values it knows. The net only
+#: scores *unlisted* values, and those must not be lifted into this band by
+#: rescaling - the obvious ``1 - bias * (1 - raw)`` promotes weak
+#: recognitions across pipeline confidence thresholds. Keeping the map an
+#: identity from here up, and a ramp below, makes that impossible.
 ENTITY_HINT_IDENTITY = 0.9
 
 #: Raw ``Entity.match`` score above which the value set is considered to have
@@ -63,8 +64,10 @@ def hint_confidence(raw: float) -> float:
 
     Below :data:`ENTITY_HINT_IDENTITY` the score is ramped from the floor by a
     square root, so the interesting, weakly-recognised end of the range gets
-    most of the resolution. At and above it the map is the identity, which is
-    what stops a listed value from ever gaining confidence.
+    most of the resolution. At and above it the map is the identity: a listed
+    value arrives here as an exact 1.0 (``Entity.samples``) and passes through
+    unchanged, and an unlisted value the net happens to score highly is not
+    rescaled any further.
     """
     raw = min(1.0, max(0.0, raw))
     if raw >= ENTITY_HINT_IDENTITY:
@@ -127,10 +130,11 @@ class PosIntent:
                 extracted = orig_data.sent[l_pos:r_pos + 1]
 
                 pos_conf = (l_conf - 0.5 + r_conf - 0.5) / 2 + 0.5
-                # entity value sets are training hints, not vocabularies: the
-                # set may lift a candidate above the floor but never sink one
-                # below it, so an unlisted value is never collapsed (and so
-                # never discarded) - and an in-list value never *gains*
+                # entity value sets are training hints, not vocabularies:
+                # a LISTED value short-circuits to exactly 1.0 through
+                # Entity.samples, scoring as if no hint were attached, and an
+                # unlisted value is floor-ramped by the net - never collapsed
+                # (and so never discarded)
                 raw = 1.0
                 if entity:
                     raw = min(1.0, max(0.0, entity.match(extracted)))

--- a/ovos_padatious/training_manager.py
+++ b/ovos_padatious/training_manager.py
@@ -87,7 +87,10 @@ class TrainingManager:
             hash_fn = join(self.cache, name + '.hash')
             old_hsh = None
             min_ver = splitext(ovos_padatious.__version__)[0]
-            new_hsh = lines_hash([min_ver] + lines)
+            # cache format 2: entities persist their value set in a .samples
+            # sidecar for the exact-match path; salting the hash retrains
+            # pre-sidecar caches once so the sidecar exists everywhere
+            new_hsh = lines_hash([min_ver, "format2"] + lines)
 
             if isfile(hash_fn):
                 with open(hash_fn, 'rb') as g:

--- a/tests/test_entity_hints.py
+++ b/tests/test_entity_hints.py
@@ -305,28 +305,57 @@ def test_subset_span_survives(timer_grammar):
     assert '3' in kept, "a subset of the recognised span must survive"
 
 
-def test_in_list_value_never_gains_confidence():
-    """Mutant killed: rescaling instead of flooring.
+def test_in_list_value_scores_as_hintless_baseline():
+    """A listed value must score exactly as if the entity were not attached.
 
-    ``Entity.match`` is a neural net, so a listed value scores ~0.91, not 1.0.
-    A rescale would lift that and promote in-list matches across a pipeline
-    confidence band. Pin the pre-fix value: this utterance measures 0.9318 on
-    dev and must not reach conf_high (0.95).
+    Attaching an ``.entity`` file is a hint, and OVOS-INTENT-1 5.4 says a hint
+    biases scoring, it never punishes: for a value the set *knows*, the
+    arithmetic must be bit-identical to the same grammar with no entity at
+    all (``ent_conf == 1.0`` both ways). The exact-sample path guarantees
+    this deterministically — before it, the net scored listed values ~0.91,
+    so registering an entity silently LOWERED every listed value's final
+    confidence below ``conf_high`` (the finding-38 regression: a default
+    high-only pipeline then dropped the utterance entirely).
+
+    Out-of-list values keep the floor-ramped net score, so this does not
+    reintroduce the rescaling promotion the hint ramp was designed against:
+    unknown values still cannot be lifted by the map.
     """
-    c = IntentContainer(tempfile.mkdtemp())
-    c.add_intent('weather', ['what is the weather in {location}',
-                             'weather in {location}',
-                             'weather for {location} today'])
-    c.add_entity('location', ['london', 'york', 'porto', 'the hague'])
-    c.train(debug=False)
+    grammar = ['what is the weather in {location}',
+               'weather in {location}',
+               'weather for {location} today']
 
-    match = c.calc_intent('what is the weather in porto today')
-    assert match.matches.get('location') == 'porto'
-    assert match.conf == pytest.approx(0.9318, abs=5e-3)
-    assert match.conf < 0.95, "in-list match must not be promoted to conf_high"
+    hinted = IntentContainer(tempfile.mkdtemp())
+    hinted.add_intent('weather', grammar)
+    hinted.add_entity('location', ['london', 'york', 'porto', 'the hague'])
+    hinted.train(debug=False)
+
+    bare = IntentContainer(tempfile.mkdtemp())
+    bare.add_intent('weather', grammar)
+    bare.train(debug=False)
+
+    # the hint-less identity is pinned at the unit level (Entity.match on a
+    # listed value returns exactly 1.0, and hint_confidence(1.0) is the
+    # identity); at container level the bare grammar is not a usable control
+    # because padaos' unconstrained {location} wildcard turns any value into
+    # a perfect 1.0 match. Pin the restored value instead: with ent_conf 1.0
+    # this utterance scores ~0.9547 — back ABOVE conf_high (0.95), which is
+    # where it routed on stable releases (no auto-registered entities), and
+    # up from the regressed 0.9318 the old pin froze
+    utt = 'what is the weather in porto today'
+    hinted_match = hinted.calc_intent(utt)
+    assert hinted_match.matches.get('location') == 'porto'
+    assert hinted_match.conf == pytest.approx(0.9547, abs=5e-3)
+    assert hinted_match.conf > 0.95
 
     # exact template matches are untouched too
-    assert c.calc_intent('weather in porto').conf == pytest.approx(1.0, abs=1e-6)
+    assert hinted.calc_intent('weather in porto').conf == pytest.approx(1.0, abs=1e-6)
+
+    # and an UNLISTED value must still not be promoted to the identity band:
+    # the ramp caps its contribution below ENTITY_HINT_IDENTITY
+    unlisted = hinted.calc_intent('what is the weather in zanzibar today')
+    listed = hinted_match.conf
+    assert unlisted.conf < listed, "unknown value must rank below a listed one"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_entity_scale.py
+++ b/tests/test_entity_scale.py
@@ -1,0 +1,116 @@
+"""Entity training must stay bounded and deterministic for large value sets.
+
+Auto-registered ``.entity`` files (ovos-workshop 9.5.0a1+) can carry thousands
+of values; the engine owns choosing a subset it can consume. These tests pin:
+
+* a listed value scores exactly 1.0 through ``Entity.match`` (deterministic
+  exact path, no net variance);
+* the net's vocabulary stays bounded no matter how large the entity file is;
+* the strided subset pick is deterministic and keeps both endpoints;
+* samples survive a cache round trip.
+"""
+import shutil
+import tempfile
+import unittest
+
+from ovos_padatious import IntentContainer
+from ovos_padatious.util import tokenize
+from ovos_padatious.entity import (Entity, ENTITY_NET_TRAINING_CAP,
+                                   _strided_subset)
+
+
+class TestStridedSubset(unittest.TestCase):
+    def test_under_cap_is_identity(self):
+        sents = [(str(i),) for i in range(10)]
+        self.assertEqual(_strided_subset(sents, 256), set(sents))
+
+    def test_over_cap_bounds_and_keeps_endpoints(self):
+        sents = [(f"{i:05d}",) for i in range(5000)]
+        picked = _strided_subset(sents, 256)
+        self.assertEqual(len(picked), 256)
+        self.assertIn(sents[0], picked)
+        self.assertIn(sents[-1], picked)
+
+    def test_deterministic(self):
+        sents = [(f"{i:05d}",) for i in range(3000)]
+        self.assertEqual(_strided_subset(sents, 256),
+                         _strided_subset(sents, 256))
+
+
+class TestLargeEntityTraining(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.container = IntentContainer(self.tmp)
+        self.values = [f"thing{i:04d}" for i in range(2000)]
+        self.container.add_entity("item", self.values)
+        self.container.add_intent("get", ["fetch {item} now", "grab {item}"])
+        self.container.train(debug=False, single_thread=True)
+        self.entity = self.container.entities.entity_dict.get("{item}")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_listed_value_scores_exactly_one(self):
+        self.assertIsNotNone(self.entity)
+        for value in ("thing0000", "thing1234", "thing1999"):
+            self.assertEqual(self.entity.match(tokenize(value)), 1.0)
+
+    def test_all_values_kept_as_samples(self):
+        self.assertEqual(len(self.entity.samples), len(self.values))
+
+    def test_net_vocabulary_is_bounded(self):
+        # vocab comes from at most ENTITY_NET_TRAINING_CAP positives (plus
+        # the handful of structural ids), never from all 2000 values
+        self.assertLessEqual(len(self.entity.ids),
+                             ENTITY_NET_TRAINING_CAP + 32)
+
+    def test_unlisted_value_still_scored_by_net(self):
+        conf = self.entity.match(["somethingelse"])
+        self.assertGreaterEqual(conf, 0.0)
+        self.assertLess(conf, 1.0)
+
+    def test_samples_survive_cache_roundtrip(self):
+        fresh = IntentContainer(self.tmp)
+        fresh.add_entity("item", self.values)
+        fresh.add_intent("get", ["fetch {item} now", "grab {item}"])
+        fresh.train(debug=False, single_thread=True)  # cache hit, no retrain
+        ent = fresh.entities.entity_dict.get("{item}")
+        self.assertEqual(ent.match(tokenize("thing1234")), 1.0)
+        self.assertEqual(len(ent.samples), len(self.values))
+
+
+
+
+class TestCacheFormatUpgrade(unittest.TestCase):
+    def test_pre_sidecar_cache_retrains_once(self):
+        import glob
+        from os.path import join
+        from ovos_padatious.util import lines_hash
+        tmp = tempfile.mkdtemp()
+        c = IntentContainer(tmp)
+        c.add_entity("item", ["london", "porto"])
+        c.add_intent("go", ["travel to {item}"])
+        c.train(debug=False)
+        sidecars = glob.glob(join(tmp, "*.samples"))
+        self.assertTrue(sidecars, "training must write the samples sidecar")
+        # simulate a pre-format2 cache: old-style hash, no sidecar
+        import ovos_padatious
+        from os.path import splitext
+        min_ver = splitext(ovos_padatious.__version__)[0]
+        for f in sidecars:
+            import os
+            os.remove(f)
+        ent_hash = [f for f in glob.glob(join(tmp, "*.hash")) if "item" in f][0]
+        with open(ent_hash, "wb") as f:
+            f.write(lines_hash([min_ver] + ["london", "porto"]))
+        fresh = IntentContainer(tmp)
+        fresh.add_entity("item", ["london", "porto"])
+        fresh.add_intent("go", ["travel to {item}"])
+        fresh.train(debug=False)
+        self.assertTrue(glob.glob(join(tmp, "*.samples")),
+                        "stale-format cache must retrain and restore the sidecar")
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

Entity training cost was superlinear in `.entity` file size: the per-entity neural net's input width is the entity's whole vocabulary and its training rows grow with the sample count, and past a few hundred diverse samples the net stops converging, so all ten training restarts burn their full 1000-epoch budget. Measured on a realistic two-entity workload of ~2200 diverse values each: training was killed at 570 seconds unfixed and takes about one second fixed. This matters now because ovos-workshop 9.5.0a1 auto-registers every shipped `.entity` file, and skills carrying large lists (a 2195-value entity measured 228s to service-ready on a cold boot) deterministically blow CI ready-timeouts.

The engine now owns its subset, per the ruling that intent engines must accept unbounded data and choose what they can consume: `Entity.train` feeds the net a deterministic, evenly-strided pick of at most 128 positive and 128 negative sentences. The full value set is kept on the entity and persisted in a `.samples` sidecar, and `Entity.match` checks it first: a listed value scores exactly 1.0, deterministically, instead of the net's ~0.91.

That exact-match path is a deliberate semantic change and fixes the finding-38 confidence regression at its root: registering an entity used to silently LOWER a listed value's final confidence below `conf_high` (0.9318 vs the 0.9547 the same utterance scores with `ent_conf` 1.0), so default high-only pipelines dropped utterances whose slot value was in the shipped list — and out-of-list finals straddled `conf_high` nondeterministically across retrainings. In-list arithmetic is now bit-identical to the hint-less baseline, which is how those utterances routed on stable releases, where nothing auto-registered entities. Out-of-list values keep the floor-ramped hint band and still rank strictly below listed ones. The `test_in_list_value_never_gains_confidence` pin was rewritten accordingly: it had frozen the regressed value itself; the no-promotion property it guarded still holds for unknown values and stays pinned.

The training-cache hash is salted with a format marker so existing caches retrain once on upgrade and gain the sidecar; caches loaded read-only without one (shipped pretrained caches) fall back to net scoring, exactly the old behavior. Fail-before evidence: the new tests error/fail on unfixed code, and the unfixed timing probe was killed at 570s where the fixed run finishes in ~1s. Full suite: 141 passed, 2 skipped, plus 4 pre-existing context-gating failures present with and without the change (verified by patch-revert baseline, stable across five runs). Docs: prerelease-quirks entry for 2.0.5a1.
