### PR TITLE
fix: default conf_high to the entity-hint identity boundary

### DIFF
--- a/docs/prerelease-quirks.md
+++ b/docs/prerelease-quirks.md
@@ -4,6 +4,18 @@ This page tracks user-visible behavior changes since the last stable release,
 `1.4.3`. Newest first. Package name on PyPI is `ovos-padatious`; this repo is
 `ovos-padatious-pipeline-plugin`. Resets to empty at the next stable release.
 
+## 2.0.5a1 — default `conf_high` lowered to the hint-identity boundary (0.9)
+
+The plugin-internal default for `conf_high` moves from 0.95 to 0.9, aligned
+with `ENTITY_HINT_IDENTITY`. Out-of-list slot values blend to final
+confidences in the low 0.94s, which straddled the old threshold
+nondeterministically across training runs: the same install routed the same
+utterance at high confidence or not at all depending on how the nets
+converged. With 0.9 the entire entity-hint band clears the high stage
+deterministically. Explicit `conf_high` values in config keep winning — the
+shipped OVOS default config sets its own value, so default installs follow
+the ovos-config release, not this fallback.
+
 ## 2.0.4a1 — `tokenize()` no longer splits underscore/digit slot names
 
 `{thing_name}` used to tokenize as `['{thing', '_', 'name}']` instead of one

--- a/ovos_padatious/opm.py
+++ b/ovos_padatious/opm.py
@@ -198,7 +198,14 @@ class PadatiousPipeline(ConfidenceMatcherPipeline):
         if self.lang not in langs:
             langs.append(self.lang)
 
-        self.conf_high = self.config.get("conf_high") or 0.95
+        # conf_high defaults to the entity-hint identity boundary
+        # (pos_intent.ENTITY_HINT_IDENTITY): a candidate whose slot value the
+        # hint set does not know blends to a final confidence in the low
+        # 0.94s, which straddled the old 0.95 threshold across training runs
+        # — the same install routed the same utterance high or not at all
+        # depending on how the nets converged. 0.9 puts the whole hint band
+        # on the high side deterministically.
+        self.conf_high = self.config.get("conf_high") or 0.9
         self.conf_med = self.config.get("conf_med") or 0.8
         self.conf_low = self.config.get("conf_low") or 0.5
 

--- a/tests/test_conf_thresholds.py
+++ b/tests/test_conf_thresholds.py
@@ -1,0 +1,33 @@
+"""Default confidence thresholds.
+
+``conf_high`` defaults to the entity-hint identity boundary (0.9,
+``pos_intent.ENTITY_HINT_IDENTITY``): out-of-list slot values blend to final
+confidences in the low 0.94s, which straddled a 0.95 threshold
+nondeterministically across training runs. The whole hint band must sit on
+the high side, deterministically.
+"""
+import unittest
+
+from unittest import mock
+
+from ovos_padatious.opm import PadatiousPipeline
+from ovos_padatious.pos_intent import ENTITY_HINT_IDENTITY
+
+
+class TestDefaultThresholds(unittest.TestCase):
+    def test_defaults(self):
+        p = PadatiousPipeline(mock.Mock(), {"any": 1})  # non-empty: skip Configuration() fallback
+        self.assertEqual(p.conf_high, ENTITY_HINT_IDENTITY)
+        self.assertEqual(p.conf_high, 0.9)
+        self.assertEqual(p.conf_med, 0.8)
+        self.assertEqual(p.conf_low, 0.5)
+        self.assertLess(p.conf_med, p.conf_high)
+        self.assertLess(p.conf_low, p.conf_med)
+
+    def test_config_override_wins(self):
+        p = PadatiousPipeline(mock.Mock(), {"conf_high": 0.95})
+        self.assertEqual(p.conf_high, 0.95)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

Withdrawn after adversarial review and re-measurement. The stated rationale was wrong: training is deterministic per training data (the numpy trainer seeds from a CRC32 of the data), so there is no per-boot coin flip. The variance is per-install — confidences depend on every skill's grammar in the container — which is exactly why no fixed threshold works: measured on current dev, legitimate out-of-list values (0.884–0.917) interleave with cross-skill and compound-utterance captures (0.883–0.922), and the bands shift with the installed skill set. Lowering conf_high admits word-salad into padatious-high ahead of adapt-high and every fallback on some installs while still missing legitimate values on others. The structural fix for out-of-list routing is a medium stage in the pipeline (see ovos-config#289), which fires only after all high stages pass, making the band overlap harmless.
