### PR TITLE
fix: slot blacklists match by whole-value equality

### DIFF
--- a/docs/prerelease-quirks.md
+++ b/docs/prerelease-quirks.md
@@ -4,6 +4,16 @@ This page tracks user-visible behavior changes since the last stable release,
 `1.4.3`. Newest first. Package name on PyPI is `ovos-padatious`; this repo is
 `ovos-padatious-pipeline-plugin`. Resets to empty at the next stable release.
 
+## 2.0.6a1 — slot blacklists match by whole-value equality
+
+An INTENT-2 §4.3 slot blacklist now drops a bound value only when the whole
+captured value equals a blacklisted entry (case-insensitive, whitespace
+collapsed). It previously matched by word-subsequence containment, which
+made every multi-word value containing a blacklisted token unmatchable — a
+pronoun blacklist collaterally blocked real titles like "her majesty",
+"the it crowd" or "it takes two". Bare blacklisted values ("it", "he") are
+dropped exactly as before.
+
 ## 2.0.5a1 — entity training bounded; listed values score exactly 1.0
 
 Entity value sets of any size now train in roughly constant time. The

--- a/ovos_padatious/opm.py
+++ b/ovos_padatious/opm.py
@@ -835,23 +835,6 @@ class PadatiousPipeline(ConfidenceMatcherPipeline):
             self._fill_context_slots(best, sess)
             return best
 
-    @staticmethod
-    def _word_seq_in(needle: str, haystack: str) -> bool:
-        """True when ``needle`` occurs in ``haystack`` as a whole-word sequence.
-
-        Comparison is case-insensitive and whitespace-collapsed; the needle's
-        tokens must appear as a contiguous run of whole words in the haystack,
-        so ``he`` matches ``he`` but not ``the`` or ``header``.
-        """
-        n = str(needle).lower().split()
-        h = str(haystack).lower().split()
-        if not n or len(n) > len(h):
-            return False
-        for i in range(len(h) - len(n) + 1):
-            if h[i:i + len(n)] == n:
-                return True
-        return False
-
     def _fill_context_slots(self, intent: PadatiousIntent, sess: Session) -> None:
         """OVOS-CONTEXT-1 §7 — uniform context slot fill.
 
@@ -870,10 +853,15 @@ class PadatiousPipeline(ConfidenceMatcherPipeline):
             return
         matches = dict(intent.matches or {})
 
-        # INTENT-2 §4.3: unresolve blacklisted slot values.
+        # INTENT-2 §4.3: unresolve blacklisted slot values. The blacklist
+        # matches by WHOLE-VALUE equality (normalized): a bare anaphoric
+        # "it" is dropped, but a multi-word value that merely contains a
+        # blacklisted word ("the it crowd", "her majesty") is a legitimate
+        # binding and must survive.
         for slot, values in self._intent_slot_blacklists.get(intent.name, {}).items():
             bound = matches.get(slot)
-            if bound is not None and any(self._word_seq_in(v, bound) for v in values):
+            if bound is not None and any(
+                    v.lower().split() == bound.lower().split() for v in values):
                 LOG.debug(f"Padatious slot '{slot}'='{bound}' blacklisted "
                           f"(INTENT-2 §4.3): treating as unresolved")
                 matches.pop(slot, None)

--- a/tests/test_context_gating.py
+++ b/tests/test_context_gating.py
@@ -221,6 +221,19 @@ class TestContextSlotFill(TestCase):
         result = self.pipeline.calc_intent("how tall is Theo", "en-US", msg)
         self.assertEqual(result.matches.get("person"), "Theo")
 
+    def test_multiword_value_containing_blacklisted_word_survives(self):
+        """INTENT-2 §4.3 blacklists match by whole-value equality: 'her
+        majesty' and 'the it crowd' are legitimate bindings even though they
+        contain blacklisted pronoun tokens."""
+        self.pipeline.handle_register_template(
+            height_msg(slot_blacklist={"person": ["he", "she", "it", "her"]}))
+        for value in ("her majesty", "the it crowd", "it takes two"):
+            self._stub_match(matches={"person": value})
+            msg = utter_msg({f"{SKILL}:person": {"value": "Alice"}})
+            result = self.pipeline.calc_intent(f"how tall is {value}",
+                                               "en-US", msg)
+            self.assertEqual(result.matches.get("person"), value)
+
     def test_blacklisted_but_no_context_stays_unresolved(self):
         """A blacklisted value with no context candidate is simply dropped."""
         self.pipeline.handle_register_template(


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

INTENT-2 §4.3 slot blacklists exist so an anaphoric pronoun never consumes an open slot ("tell me about it" leaves the slot for context to fill). The enforcement compared by word-subsequence containment, so any multi-word value merely containing a blacklisted token was dropped too: with a pronoun blacklist, "her majesty", "the it crowd" and "it takes two" all became unmatchable and the skill reprompted — executed reproductions from the wikipedia skill gate. The docstring already described the intended semantics ("a value listed in that slot's blacklist"); containment was the bug.

The comparison is now whole-value equality, case-insensitive and whitespace-collapsed. Bare blacklisted values drop exactly as before, context refill is unchanged, and the now-unused word-subsequence helper is removed. A regression test pins the three collateral titles surviving a pronoun blacklist; verified fail-before by patch-revert. Full suite: 146 passed, 2 skipped. Docs: prerelease-quirks entry for 2.0.6a1.
