### PR TITLE
fix: intent suppression covers exact matches and uses word boundaries

### DIFF
--- a/docs/prerelease-quirks.md
+++ b/docs/prerelease-quirks.md
@@ -4,6 +4,15 @@ This page tracks user-visible behavior changes since the last stable release,
 `1.4.3`. Newest first. Package name on PyPI is `ovos-padatious`; this repo is
 `ovos-padatious-pipeline-plugin`. Resets to empty at the next stable release.
 
+## 2.0.7a1 — intent suppression: no exact-match bypass, word boundaries
+
+`blacklisted_words` suppression now applies to padaos exact template
+matches too: an utterance that perfectly matched a template previously
+scored 1.0 and bypassed the blacklist entirely (only neural candidates were
+filtered). And the word check now matches at word boundaries instead of raw
+substring: "install" suppresses "install firefox" but no longer suppresses
+"what is an installment loan".
+
 ## 2.0.6a1 — slot blacklists match by whole-value equality
 
 An INTENT-2 §4.3 slot blacklist now drops a bound value only when the whole

--- a/ovos_padatious/intent_container.py
+++ b/ovos_padatious/intent_container.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import inspect
+import re
 import os
 from functools import wraps
 from typing import List, Dict, Any, Optional
@@ -290,15 +291,27 @@ class IntentContainer:
         """
         if self.must_train:
             self.train()
+
+        def suppressed(intent_name: str) -> bool:
+            # blacklisted words match at word boundaries: "install" suppresses
+            # "install firefox" but not "what is an installment loan"
+            q = query.lower()
+            return any(re.search(rf"\b{re.escape(k.lower())}\b", q)
+                       for k in self.blacklisted_words[intent_name])
+
         # post-processing: discard any matches that contain blacklisted words
         intents = {i.name: i
                    for i in self.intents.calc_intents(query, self.entities)
-                   if not any(k in query for k in self.blacklisted_words[i.name])}
+                   if not suppressed(i.name)}
         sent = tokenize(query)
 
         if self.padaos is not None:
+            # exact template matches honor the same suppression - a perfect
+            # match must not bypass the blacklist the neural tier enforces
             for perfect_match in self.padaos.calc_intents(query):
                 name = perfect_match['name']
+                if suppressed(name):
+                    continue
                 intents[name] = MatchData(name, sent, matches=perfect_match['entities'], conf=1.0)
         return list(intents.values())
 

--- a/tests/test_intent_suppression.py
+++ b/tests/test_intent_suppression.py
@@ -1,0 +1,40 @@
+"""Intent suppression (blacklisted_words): word-boundary matching, and the
+padaos exact-template tier honors it identically to the neural tier."""
+import tempfile
+import unittest
+
+from ovos_padatious import IntentContainer
+
+
+class TestIntentSuppression(unittest.TestCase):
+    def _container(self):
+        c = IntentContainer(tempfile.mkdtemp())
+        c.add_intent('wiki', ['tell me about {thing} on wikipedia',
+                              'look up {thing} on wikipedia'])
+        c.blacklisted_words['wiki'] += ['weather', 'install']
+        c.train(debug=False)
+        return c
+
+    def test_exact_template_match_is_suppressed(self):
+        c = self._container()
+        # exact template shape: padaos would score this 1.0; the blacklist
+        # must apply to that tier too, not just the neural candidates
+        matches = c.calc_intents('tell me about the weather on wikipedia')
+        self.assertEqual([m for m in matches if m.name == 'wiki'], [])
+
+    def test_word_boundary_not_substring(self):
+        c = self._container()
+        m = c.calc_intent('tell me about an installment loan on wikipedia')
+        self.assertEqual(m.name, 'wiki')
+        matches = c.calc_intents('look up how to install firefox on wikipedia')
+        self.assertEqual([x for x in matches if x.name == 'wiki'], [])
+
+    def test_unrelated_utterance_unaffected(self):
+        c = self._container()
+        m = c.calc_intent('tell me about python on wikipedia')
+        self.assertEqual(m.name, 'wiki')
+        self.assertGreater(m.conf, 0.8)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

Two defects in `blacklisted_words` intent suppression, both from the wikipedia skill re-gate. First, the bypass: the blacklist filtered only the neural candidates; the padaos loop below then unconditionally admitted exact template matches at conf 1.0, so precisely the utterances that matched best ignored suppression entirely ("tell me about the weather on wikipedia" ran the handler with "weather" blacklisted, while the same phrase through the neural tier was correctly suppressed — which is why tests never saw it). Both tiers now share one suppression check.

Second, matching: the check was raw substring, so "install" suppressed "what is an installment loan". It now matches at word boundaries (case-insensitive, phrases escaped), aligning with padacioso's semantics.

Regression tests pin the exact-match suppression, the installment/install boundary pair, and an unaffected control; verified fail-before by patch-revert (2 failures on the unfixed block). Full suite: 149 passed, 2 skipped. Docs: prerelease-quirks entry for 2.0.7a1.
